### PR TITLE
Move user role management from utility to application

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,7 +37,7 @@
             "type": "blazorwasm",
             "request": "launch",
             "hosted": true,
-            "program": "${workspaceFolder}/NRZMyk.Server/bin/Debug/netcoreapp3.1/NRZMyk.Server.dll",
+            "program": "${workspaceFolder}/NRZMyk.Server/bin/Debug/net6.0/NRZMyk.Server.dll",
             "cwd": "${workspaceFolder}/NRZMyk.Server"
         }
     ]

--- a/NRZMyk.Components/Pages/Admin.razor
+++ b/NRZMyk.Components/Pages/Admin.razor
@@ -42,6 +42,7 @@ else
                         <th>Name</th>
                         <th>Email</th>
                         <th>Ort</th>
+                        <th>Rollen</th>
                         <th>Organisation zuordnen</th>
                     </tr>
                     </thead>
@@ -52,6 +53,7 @@ else
                             <td>@item.DisplayName</td>
                             <td>@item.Email</td>
                             <td>@item.Postalcode @item.City</td>
+                            <td>@item.Role</td>
                             <td>
                                 <InputSelectNumber class="form-select form-select-sm" @bind-Value="item.OrganizationId">
                                     <option>- Keine Organisation zugeordnet -</option>

--- a/NRZMyk.Mocks/TestUtils/MockLogger.cs
+++ b/NRZMyk.Mocks/TestUtils/MockLogger.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+
+namespace NRZMyk.Mocks.TestUtils;
+
+public abstract class MockLogger<T> : ILogger<T>
+{
+    void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        => Log(logLevel, formatter(state, exception), exception);
+
+    public abstract void Log(LogLevel logLevel, object state, Exception exception = null);
+
+    public virtual bool IsEnabled(LogLevel logLevel) => true;
+
+    public abstract IDisposable BeginScope<TState>(TState state);
+}

--- a/NRZMyk.Server.Tests/Controllers/SentinelEntries/CreateTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/SentinelEntries/CreateTests.cs
@@ -5,6 +5,7 @@ using AutoMapper;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NRZMyk.Mocks.TestUtils;
 using NRZMyk.Server.Controllers.SentinelEntries;
 using NRZMyk.Services.Data;
 using NRZMyk.Services.Data.Entities;
@@ -55,21 +56,9 @@ namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
         {
             sentinelEntryRepository = Substitute.For<ISentinelEntryRepository>();
             map = Substitute.For<IMapper>();
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Host = new HostString("localhost");
-            httpContext.Request.Scheme = "http";
-            httpContext.Request.Path = new PathString("/api/sentinel-entries");
-            var identity = new ClaimsIdentity();
-            if (organizationId != null)
-            {
-                identity.AddClaim(new Claim(ClaimTypes.Organization, organizationId));
-            }
-            httpContext.User = new ClaimsPrincipal(identity);
             return new Create(sentinelEntryRepository, map)
             {
-                ControllerContext = new ControllerContext {
-                    HttpContext = httpContext,
-                }
+                ControllerContext = new MockControllerContext("/api/sentinel-entries", organizationId)
             };
         }
     }

--- a/NRZMyk.Server.Tests/Controllers/SentinelEntries/CryoArchiveTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/SentinelEntries/CryoArchiveTests.cs
@@ -4,6 +4,7 @@ using AutoMapper;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NRZMyk.Mocks.TestUtils;
 using NRZMyk.Server.Controllers.SentinelEntries;
 using NRZMyk.Services.Data.Entities;
 using NRZMyk.Services.Interfaces;
@@ -51,15 +52,9 @@ namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
             var mapper = new Mapper(configuration);
             sentinelEntryRepository = Substitute.For<IAsyncRepository<SentinelEntry>>();
 
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Host = new HostString("localhost");
-            httpContext.Request.Scheme = "http";
             return new CryoArchive(sentinelEntryRepository, mapper)
             {
-                ControllerContext = new ControllerContext
-                {
-                    HttpContext = httpContext
-                }
+                ControllerContext = new MockControllerContext()
             };
         }
     }

--- a/NRZMyk.Server.Tests/Controllers/SentinelEntries/DeleteTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/SentinelEntries/DeleteTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NRZMyk.Mocks.TestUtils;
 using NRZMyk.Server.Controllers.SentinelEntries;
 using NRZMyk.Services.Data.Entities;
 using NRZMyk.Services.Interfaces;
@@ -114,21 +115,9 @@ namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
             sentinelEntryRepository = Substitute.For<IAsyncRepository<SentinelEntry>>();
             sensitivityTestRepository = Substitute.For<IAsyncRepository<AntimicrobialSensitivityTest>>();
 
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Host = new HostString("localhost");
-            httpContext.Request.Scheme = "http";
-            var identity = new ClaimsIdentity();
-            if (organizationId != null)
-            {
-                identity.AddClaim(new Claim(ClaimTypes.Organization, organizationId));
-            }
-            httpContext.User = new ClaimsPrincipal(identity);
             return new Delete(sentinelEntryRepository, sensitivityTestRepository)
             {
-                ControllerContext = new ControllerContext
-                {
-                    HttpContext = httpContext
-                }
+                ControllerContext = new MockControllerContext(organizationId:organizationId)
             };
         }
     }

--- a/NRZMyk.Server.Tests/Controllers/SentinelEntries/ExcelExportTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/SentinelEntries/ExcelExportTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NRZMyk.Mocks.TestUtils;
 using NRZMyk.Server.Controllers.SentinelEntries;
 using NRZMyk.Services.Data.Entities;
 using NRZMyk.Services.Interfaces;
@@ -37,20 +38,12 @@ namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
         private static ExcelExport CreateSut(out IAsyncRepository<SentinelEntry> repository)
         {
             repository = Substitute.For<IAsyncRepository<SentinelEntry>>();
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Host = new HostString("localhost");
-            httpContext.Request.Scheme = "http";
-            var identity = new ClaimsIdentity();
-            httpContext.User = new ClaimsPrincipal(identity);
             var micStepsService = Substitute.For<IMicStepsService>();
             micStepsService.StepsByTestingMethodAndAgent(Arg.Any<SpeciesTestingMethod>(), Arg.Any<AntifungalAgent>())
                 .Returns(new List<MicStep>());
             return new ExcelExport(repository, Substitute.For<IProtectKeyToOrganizationResolver>(), micStepsService)
             {
-                ControllerContext = new ControllerContext
-                {
-                    HttpContext = httpContext
-                }
+                ControllerContext = new MockControllerContext()
             };
         }
     }

--- a/NRZMyk.Server.Tests/Controllers/SentinelEntries/GetByIdTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/SentinelEntries/GetByIdTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NRZMyk.Mocks.TestUtils;
 using NRZMyk.Server.Controllers.SentinelEntries;
 using NRZMyk.Services.Data.Entities;
 using NRZMyk.Services.Interfaces;
@@ -78,21 +79,9 @@ namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
         private static GetById CreateSut(out IAsyncRepository<SentinelEntry> repository, string organizationId = null)
         {
             repository = Substitute.For<IAsyncRepository<SentinelEntry>>();
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Host = new HostString("localhost");
-            httpContext.Request.Scheme = "http";
-            var identity = new ClaimsIdentity();
-            if (organizationId != null)
-            {
-                identity.AddClaim(new Claim(ClaimTypes.Organization, organizationId));
-            }
-            httpContext.User = new ClaimsPrincipal(identity);
             return new GetById(repository)
             {
-                ControllerContext = new ControllerContext
-                {
-                    HttpContext = httpContext
-                }
+                ControllerContext = new MockControllerContext(organizationId:organizationId)
             };
         }
     }

--- a/NRZMyk.Server.Tests/Controllers/SentinelEntries/ListByOrganizationTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/SentinelEntries/ListByOrganizationTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NRZMyk.Mocks.TestUtils;
 using NRZMyk.Server.Controllers.SentinelEntries;
 using NRZMyk.Services.Data.Entities;
 using NRZMyk.Services.Interfaces;
@@ -49,15 +50,9 @@ namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
         private static ListByOrganization CreateSut(out IAsyncRepository<SentinelEntry> repository)
         {
             repository = Substitute.For<IAsyncRepository<SentinelEntry>>();
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Host = new HostString("localhost");
-            httpContext.Request.Scheme = "http";
             return new ListByOrganization(repository)
             {
-                ControllerContext = new ControllerContext
-                {
-                    HttpContext = httpContext
-                }
+                ControllerContext = new MockControllerContext()
             };
         }
     }

--- a/NRZMyk.Server.Tests/Controllers/SentinelEntries/UpdateTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/SentinelEntries/UpdateTests.cs
@@ -6,6 +6,7 @@ using AutoMapper;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NRZMyk.Mocks.TestUtils;
 using NRZMyk.Server.Controllers.SentinelEntries;
 using NRZMyk.Services.Data;
 using NRZMyk.Services.Data.Entities;
@@ -122,21 +123,9 @@ namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
             sensitivityTestRepository = Substitute.For<IAsyncRepository<AntimicrobialSensitivityTest>>();
             map = Substitute.For<IMapper>();
 
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Host = new HostString("localhost");
-            httpContext.Request.Scheme = "http";
-            var identity = new ClaimsIdentity();
-            if (organizationId != null)
-            {
-                identity.AddClaim(new Claim(ClaimTypes.Organization, organizationId));
-            }
-            httpContext.User = new ClaimsPrincipal(identity);
             return new Update(sentinelEntryRepository, sensitivityTestRepository, map)
             {
-                ControllerContext = new ControllerContext
-                {
-                    HttpContext = httpContext
-                }
+                ControllerContext = new MockControllerContext(organizationId: organizationId)
             };
         }
     }

--- a/NRZMyk.Server.Tests/Controllers/User/ConnectTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/User/ConnectTests.cs
@@ -5,6 +5,7 @@ using AutoMapper;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NRZMyk.Mocks.TestUtils;
 using NRZMyk.Server.Controllers.Account;
 using NRZMyk.Services.Data.Entities;
 using NRZMyk.Services.Interfaces;
@@ -98,16 +99,9 @@ namespace NRZMyk.Server.Tests.Controllers.User
             accountRepository = Substitute.For<IAsyncRepository<RemoteAccount>>();
             map = Substitute.For<IMapper>();
             emailNotificationService = Substitute.For<IEmailNotificationService>();
-            var httpContext = new DefaultHttpContext {User = user};
-            httpContext.Request.Host = new HostString("localhost");
-            httpContext.Request.Scheme = "http";
-            httpContext.Request.Path = new PathString("/api/connect/user");
             return new Connect(accountRepository, map, emailNotificationService)
             {
-                ControllerContext = new ControllerContext
-                {
-                    HttpContext = httpContext
-                }
+                ControllerContext = new MockControllerContext("/api/connect/user", user:user)
             };
         }
     }

--- a/NRZMyk.Server.Tests/Controllers/User/ListUsersTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/User/ListUsersTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NRZMyk.Mocks.TestUtils;
+using NRZMyk.Server.Controllers.Account;
+using NRZMyk.Server.Controllers.SentinelEntries;
+using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Interfaces;
+using NRZMyk.Services.Services;
+using NRZMyk.Services.Specifications;
+using NSubstitute;
+using NUnit.Framework;
+using Tynamix.ObjectFiller;
+
+namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
+{
+    public class ListUsersTests
+    {
+        private Filler<RemoteAccount> _filler = new Filler<RemoteAccount>();
+
+        [Test]
+        public async Task WhenProtectKeyIsNegative_QueriesAllEntries()
+        {
+            var sut = CreateSut(out var repository, out var userService);
+            var expectedResult = _filler.Create(2);
+           
+            repository.ListAllAsync()
+                .Returns(Task.FromResult((IReadOnlyList<RemoteAccount>)expectedResult));
+
+            var action = await sut.HandleAsync();
+
+            action.Result.Should().BeOfType<OkObjectResult>();
+            action.Result.As<OkObjectResult>().Value.Should().Be(expectedResult);
+            await userService.Received(1).GetRolesViaGraphApi(expectedResult);
+        }
+
+
+        private static ListUsers CreateSut(out IAsyncRepository<RemoteAccount> repository, out IUserService userService)
+        {
+            repository = Substitute.For<IAsyncRepository<RemoteAccount>>();
+            userService = Substitute.For<IUserService>();
+            
+            return new ListUsers(repository, userService)
+            {
+                ControllerContext = new MockControllerContext()
+            };
+        }
+    }
+}

--- a/NRZMyk.Server.Tests/TestUtils/MockControllerContext.cs
+++ b/NRZMyk.Server.Tests/TestUtils/MockControllerContext.cs
@@ -1,0 +1,38 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using ClaimTypes = NRZMyk.Services.Models.ClaimTypes;
+
+namespace NRZMyk.Mocks.TestUtils;
+
+public class MockControllerContext: ControllerContext
+{
+    public MockControllerContext(string path = null, string organizationId = null, ClaimsPrincipal user = null)
+    {
+        HttpContext = new DefaultHttpContext
+        {
+            Request =
+            {
+                Host = new HostString("localhost"),
+                Scheme = "http",
+                Path = path
+            },
+        };
+
+        var identity = new ClaimsIdentity();
+        if (organizationId != null)
+        {
+            identity.AddClaim(new Claim(ClaimTypes.Organization, organizationId));
+        }
+
+        if (user != null)
+        {
+            user.AddIdentity(identity);
+            HttpContext.User = user;
+        }
+        else
+        {
+            HttpContext.User = new ClaimsPrincipal(identity);
+        }
+    }
+}

--- a/NRZMyk.Server.Tests/Utils/GraphServiceClientWrapperTests.cs
+++ b/NRZMyk.Server.Tests/Utils/GraphServiceClientWrapperTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Azure.Identity;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.Graph;
+using NRZMyk.Services.Configuration;
+using NRZMyk.Services.Services;
+using NUnit.Framework;
+
+namespace NRZMyk.Server.Utils;
+
+public class GraphServiceClientWrapperTests
+{
+    [Test]
+    public void CtorWithMissingConfigSection_DoesThrow()
+    {
+        Action createSut = () => new GraphServiceClientWrapper(Options.Create(new AzureAdB2CSettings()));
+
+        createSut.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void CtorWithValidConfigKeys_DoesNotThrow()
+    {
+        Action createSut = () => new GraphServiceClientWrapper(Options.Create(new AzureAdB2CSettings {AzureAdB2C = new AzureAdB2C()}));
+
+        createSut.Should().Throw<ArgumentException>();
+    }
+    
+    [Test]
+    public void CtorWithValidConfig_DoesNotThrow()
+    {
+        Action createSut = () => new GraphServiceClientWrapper(Options.Create(new AzureAdB2CSettings {AzureAdB2C = new AzureAdB2C()
+        {
+            Domain = "foo",
+            ClientId = "123",
+            ClientSecret = "321"
+        }}));
+
+        createSut.Should().NotThrow();
+    }
+
+    [Test]
+    public void WhenAccessingUsers_ShoulForwardToGraphClient()
+    {
+        var client = new GraphServiceClientWrapper(Options.Create(new AzureAdB2CSettings {AzureAdB2C = new AzureAdB2C()
+        {
+            Domain = "foo",
+            ClientId = "123",
+            ClientSecret = "321"
+        }}));
+
+        client.Users.Should().NotBeNull();
+    }
+}

--- a/NRZMyk.Server/Controllers/Account/ListUsers.cs
+++ b/NRZMyk.Server/Controllers/Account/ListUsers.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using NRZMyk.Services.Data.Entities;
 using NRZMyk.Services.Interfaces;
 using NRZMyk.Services.Models;
+using NRZMyk.Services.Services;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace NRZMyk.Server.Controllers.Account
@@ -14,10 +15,12 @@ namespace NRZMyk.Server.Controllers.Account
     public class ListUsers : BaseAsyncEndpoint<List<RemoteAccount>>
     {
         private readonly IAsyncRepository<RemoteAccount> _accountRepository;
+        private readonly IUserService _userService;
 
-        public ListUsers(IAsyncRepository<RemoteAccount> accountRepository)
+        public ListUsers(IAsyncRepository<RemoteAccount> accountRepository, IUserService userService)
         {
             _accountRepository = accountRepository;
+            _userService = userService;
         }
 
         [HttpGet("api/users")]
@@ -29,6 +32,7 @@ namespace NRZMyk.Server.Controllers.Account
         public override async Task<ActionResult<List<RemoteAccount>>> HandleAsync()
         {
             var items = await _accountRepository.ListAllAsync();
+            await _userService.UpdateRoleViaGraphApi(items);
             return Ok(items);
         }
     }

--- a/NRZMyk.Server/Controllers/Account/ListUsers.cs
+++ b/NRZMyk.Server/Controllers/Account/ListUsers.cs
@@ -32,7 +32,7 @@ namespace NRZMyk.Server.Controllers.Account
         public override async Task<ActionResult<List<RemoteAccount>>> HandleAsync()
         {
             var items = await _accountRepository.ListAllAsync();
-            await _userService.UpdateRoleViaGraphApi(items);
+            await _userService.GetRolesViaGraphApi(items);
             return Ok(items);
         }
     }

--- a/NRZMyk.Server/NRZMyk.Server.csproj
+++ b/NRZMyk.Server/NRZMyk.Server.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.39.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="6.0.0" />
+    <PackageReference Include="Azure.Identity" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NRZMyk.Server/Startup.cs
+++ b/NRZMyk.Server/Startup.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using AutoMapper;
-using MediatR;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.AzureADB2C.UI;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -20,10 +15,8 @@ using Microsoft.OpenApi.Models;
 using NRZMyk.Server.Utils;
 using NRZMyk.Services.Configuration;
 using NRZMyk.Services.Data;
-using NRZMyk.Services.Data.Entities;
 using NRZMyk.Services.Interfaces;
 using NRZMyk.Services.Services;
-using NRZMyk.Services.Specifications;
 using NRZMyk.Services.Utils;
 using SendGrid;
 using SendGrid.Extensions.DependencyInjection;
@@ -46,10 +39,6 @@ namespace NRZMyk.Server
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            //services.AddOptions<Breakpoint>()
-            //    .Bind(Configuration.GetSection(nameof(Breakpoint)))
-            //    .ValidateDataAnnotations();
-
             ConfigureAzureAdB2C(services);
             ConfigureSwagger(services);
 
@@ -150,6 +139,10 @@ namespace NRZMyk.Server
                     };
                 }
             );
+
+            services.Configure<AzureAdB2CSettings>(Configuration);
+            services.AddScoped<IGraphServiceClient, GraphServiceClientWrapper>();
+            services.AddScoped<IUserService, UserService>();
         }
 
 

--- a/NRZMyk.Server/Utils/GraphServiceClientWrapper.cs
+++ b/NRZMyk.Server/Utils/GraphServiceClientWrapper.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Identity;
+﻿using System;
+using Azure.Identity;
 using Microsoft.Extensions.Options;
 using Microsoft.Graph;
 using NRZMyk.Services.Configuration;
@@ -16,6 +17,13 @@ public class GraphServiceClientWrapper : IGraphServiceClient
 
     public GraphServiceClientWrapper(IOptions<AzureAdB2CSettings> config)
     {
+        if (config?.Value?.AzureAdB2C == null)
+        {
+            throw new ArgumentException(
+                $"Configuration for {nameof(AzureAdB2CSettings.AzureAdB2C)} is not found.",
+                nameof(config));
+        }
+
         var settings = config.Value.AzureAdB2C;
         var clientSecretCredential = new ClientSecretCredential(settings.Domain, settings.ClientId, settings.ClientSecret);
         _graphClient = new GraphServiceClient(clientSecretCredential, Scopes);

--- a/NRZMyk.Server/Utils/GraphServiceClientWrapper.cs
+++ b/NRZMyk.Server/Utils/GraphServiceClientWrapper.cs
@@ -1,0 +1,23 @@
+﻿using Azure.Identity;
+using Microsoft.Extensions.Options;
+using Microsoft.Graph;
+using NRZMyk.Services.Configuration;
+using NRZMyk.Services.Services;
+
+namespace NRZMyk.Server.Utils;
+
+public class GraphServiceClientWrapper : IGraphServiceClient
+{
+    private static readonly string[] Scopes = { "https://graph.microsoft.com/.default" };
+    
+    private readonly GraphServiceClient _graphClient;
+
+    public IGraphServiceUsersCollectionRequestBuilder Users => _graphClient.Users;
+
+    public GraphServiceClientWrapper(IOptions<AzureAdB2CSettings> config)
+    {
+        var settings = config.Value.AzureAdB2C;
+        var clientSecretCredential = new ClientSecretCredential(settings.Domain, settings.ClientId, settings.ClientSecret);
+        _graphClient = new GraphServiceClient(clientSecretCredential, Scopes);
+    }
+}

--- a/NRZMyk.Server/appsettings.json
+++ b/NRZMyk.Server/appsettings.json
@@ -16,8 +16,10 @@
   "AzureAdB2C": {
     "Instance": "https://nrcmycosis.b2clogin.com",
     "ClientId": "[Enter the Client Id (Application ID obtained from the Azure portal), e.g. ba74781c2-53c2-442a-97c2-3d60re42f403]",
+    "B2cExtensionAppClientId": "[Find this application (client) ID in the App registrations pane in the Azure portal (all applications). The app registration is named 'b2c-extensions-app. Do not modify. Used by AADB2C for storing user data.'.]",
     "Domain": "[Enter the domain of your tenant, e.g. contoso.onmicrosoft.com]",
-    "SignUpSignInPolicyId": "[Enter the signin policy name, e.g. B2C_1_Signin]"
+    "SignUpSignInPolicyId": "[Enter the signin policy name, e.g. B2C_1_Signin]",
+    "ClientSecret": "[Secret used for server-side graph client]" 
   },
   "AllowedHosts": "*",
   "DatabaseSeed": {

--- a/NRZMyk.Services.Tests/NRZMyk.Services.Tests.csproj
+++ b/NRZMyk.Services.Tests/NRZMyk.Services.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\NRZMyk.Mocks\NRZMyk.Mocks.csproj" />
     <ProjectReference Include="..\NRZMyk.Services\NRZMyk.Services.csproj" />
   </ItemGroup>
 </Project>

--- a/NRZMyk.Services.Tests/Services/UserServiceTests.cs
+++ b/NRZMyk.Services.Tests/Services/UserServiceTests.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -64,7 +67,131 @@ public class UserServiceTests
             s => new Regex("Failed to update.*Admin.*123").IsMatch(s)), exception);
     }
 
-    private static UserService CreateSut(out IGraphServiceClient graphServiceClient, out IOptions<AzureAdB2CSettings> settings, out MockLogger<UserService> logger)
+
+    [Test]
+    public async Task WhenGettingRolesWithEmptyList_DoesNothing()
+    {
+        var sut = CreateSut(out _, out _, out _);
+        var remoteAccounts = new List<RemoteAccount>();
+
+        await sut.GetRolesViaGraphApi(remoteAccounts);
+
+        remoteAccounts.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task WhenRemoteRequestFailed_LogsErrorAndSetsGuestRole()
+    {
+        var guid = Guid.NewGuid();
+        var remoteAccounts = new List<RemoteAccount>
+        {
+            new() { ObjectId = guid },
+        };
+        var sut = CreateSut(out var graphServiceClient, out _, out var logger);
+        var serviceException = new ServiceException(new Error(), null, HttpStatusCode.BadRequest);
+        graphServiceClient.Users[guid.ToString()].Throws(serviceException);
+
+        await sut.GetRolesViaGraphApi(remoteAccounts);
+
+        remoteAccounts.Should().OnlyContain(a => a.Role == Role.Guest);
+        logger.Received(1).Log(LogLevel.Error, Arg.Is<string>(s => s.StartsWith(
+            $"Failed to query user with ID {guid}")), serviceException);
+    }
+
+    [Test]
+    public async Task WhenRemoteUserNotFound_LogsWarningAndSetsGuestRole()
+    {
+        var guid = Guid.NewGuid();
+        var remoteAccounts = new List<RemoteAccount>
+        {
+            new() { ObjectId = guid },
+        };
+        var sut = CreateSut(out var graphServiceClient, out _, out var logger);
+        var serviceException = new ServiceException(new Error(), null, HttpStatusCode.NotFound);
+        graphServiceClient.Users[guid.ToString()].Throws(serviceException);
+
+        await sut.GetRolesViaGraphApi(remoteAccounts);
+
+        remoteAccounts.Should().OnlyContain(a => a.Role == Role.Guest);
+        logger.Received(1).Log(LogLevel.Warning, Arg.Is<string>(s => s.StartsWith(
+            $"User with ID {guid} was not found")));
+    }
+
+    [Test]
+    public async Task WhenGettingRolesForTwoRemoteAccounts_QueriesTwoUsers()
+    {
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+        var remoteAccounts = new List<RemoteAccount>
+        {
+            new() { ObjectId = guid1 },
+            new() { ObjectId = guid2 }
+        };
+        var sut = CreateSut(out var graphServiceClient, out _, out var logger);
+        var userRequest = Substitute.For<IUserRequest>();
+        var userRequestBuilder = Substitute.For<IUserRequestBuilder>();
+        userRequestBuilder.Request().Returns(userRequest);
+        userRequest.Select($"id,displayName,{RoleCompleteAttributeName}").Returns(userRequest);
+        userRequest.GetAsync().Returns(new User
+            { AdditionalData = new Dictionary<string, object> { { RoleCompleteAttributeName, "4" } } });
+        graphServiceClient.Users[guid1.ToString()].Returns(userRequestBuilder);
+        graphServiceClient.Users[guid2.ToString()].Returns(userRequestBuilder);
+
+        await sut.GetRolesViaGraphApi(remoteAccounts);
+
+        userRequest.Received(2).Select(Arg.Any<string>());
+        remoteAccounts.Should().OnlyContain(a => a.Role == Role.SuperUser);
+    }
+
+    [Test]
+    public async Task WhenUserDoesNotHaveRoleAssigned_SetsGuestRole()
+    {
+        var guid = Guid.NewGuid();
+        var remoteAccounts = new List<RemoteAccount>
+        {
+            new() { ObjectId = guid },
+        };
+        var sut = CreateSut(out var graphServiceClient, out _, out var logger);
+        var userRequest = Substitute.For<IUserRequest>();
+        var userRequestBuilder = Substitute.For<IUserRequestBuilder>();
+        userRequestBuilder.Request().Returns(userRequest);
+        userRequest.Select($"id,displayName,{RoleCompleteAttributeName}").Returns(userRequest);
+        userRequest.GetAsync().Returns(new User { AdditionalData = null });
+        graphServiceClient.Users[guid.ToString()].Returns(userRequestBuilder);
+
+        await sut.GetRolesViaGraphApi(remoteAccounts);
+
+        userRequest.Received(1).Select(Arg.Any<string>());
+        remoteAccounts.Should().OnlyContain(a => a.Role == Role.Guest);
+    }
+
+    [TestCase("")]
+    [TestCase("1234")]
+    [TestCase(null)]
+    public async Task WhenRolesAttributeIsInvalid_SetsGuestRole(string role)
+    {
+        var guid = Guid.NewGuid();
+        var remoteAccounts = new List<RemoteAccount>
+        {
+            new() { ObjectId = guid },
+        };
+        var sut = CreateSut(out var graphServiceClient, out _, out var logger);
+        var userRequest = Substitute.For<IUserRequest>();
+        var userRequestBuilder = Substitute.For<IUserRequestBuilder>();
+        userRequestBuilder.Request().Returns(userRequest);
+        userRequest.Select($"id,displayName,{RoleCompleteAttributeName}").Returns(userRequest);
+        userRequest.GetAsync().Returns(new User
+            { AdditionalData = new Dictionary<string, object> { { RoleCompleteAttributeName, role } } });
+        graphServiceClient.Users[guid.ToString()].Returns(userRequestBuilder);
+
+        await sut.GetRolesViaGraphApi(remoteAccounts);
+
+        userRequest.Received(1).Select(Arg.Any<string>());
+        remoteAccounts.Should().OnlyContain(a => a.Role == Role.Guest);
+    }
+
+    private static UserService CreateSut(out IGraphServiceClient graphServiceClient,
+        out IOptions<AzureAdB2CSettings> settings, out MockLogger<UserService> logger)
     {
         settings = Options.Create(new AzureAdB2CSettings());
         settings.Value.AzureAdB2C = new AzureAdB2C()

--- a/NRZMyk.Services.Tests/Services/UserServiceTests.cs
+++ b/NRZMyk.Services.Tests/Services/UserServiceTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Graph;
+using NRZMyk.Mocks.TestUtils;
+using NRZMyk.Services.Configuration;
+using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Models;
+using NRZMyk.Services.Services;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+
+namespace NRZMyk.Services.Tests.Services;
+
+public class UserServiceTests
+{
+    private const string B2CExtensionAppClientId = "1234-5678";
+    private const string RoleCompleteAttributeName = "extension_12345678_Role";
+
+    [Test]
+    public void Ctor_ThrowsOnMissingConfig()
+    {
+        Action createSut = () => new UserService(Substitute.For<IGraphServiceClient>(),
+            Options.Create(new AzureAdB2CSettings()), Substitute.For<ILogger<UserService>>());
+
+        createSut.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public async Task WhenUpdatingRole_SendsUpdateRequestToToGraphClient()
+    {
+        const string userId = "123";
+        User updatedUser = null;
+        var sut = CreateSut(out var graphServiceClient, out _, out var logger);
+        var userRequest = Substitute.For<IUserRequest>();
+        await userRequest.UpdateAsync(Arg.Do<User>(arg => updatedUser = arg));
+        var userRequestBuilder = Substitute.For<IUserRequestBuilder>();
+        userRequestBuilder.Request().Returns(userRequest);
+        graphServiceClient.Users[userId].Returns(userRequestBuilder);
+
+        await sut.UpdateUserRole(userId, Role.Admin);
+
+        updatedUser.Should().NotBeNull();
+        updatedUser.AdditionalData[RoleCompleteAttributeName].Should().Be("8");
+        logger.Received(1).Log(LogLevel.Information, Arg.Is<string>(
+            s => new Regex("Updated role.*Admin.*123").IsMatch(s)));
+    }
+
+    [Test]
+    public async Task WhenUpdatingFails_LogsError()
+    {
+        const string userId = "123";
+        var sut = CreateSut(out var graphServiceClient, out _, out var logger);
+        var exception = new Exception();
+        graphServiceClient.Users[userId].Throws(exception);
+
+        await sut.UpdateUserRole(userId, Role.Admin);
+
+        logger.Received(1).Log(LogLevel.Error, Arg.Is<string>(
+            s => new Regex("Failed to update.*Admin.*123").IsMatch(s)), exception);
+    }
+
+    private static UserService CreateSut(out IGraphServiceClient graphServiceClient, out IOptions<AzureAdB2CSettings> settings, out MockLogger<UserService> logger)
+    {
+        settings = Options.Create(new AzureAdB2CSettings());
+        settings.Value.AzureAdB2C = new AzureAdB2C()
+        {
+            B2cExtensionAppClientId = B2CExtensionAppClientId
+        };
+        graphServiceClient = Substitute.For<IGraphServiceClient>();
+        logger = Substitute.For<MockLogger<UserService>>();
+        return new UserService(graphServiceClient, settings, logger);
+    }
+}

--- a/NRZMyk.Services/Configuration/AzureAdB2C.cs
+++ b/NRZMyk.Services/Configuration/AzureAdB2C.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Graph.ExternalConnectors;
+
+namespace NRZMyk.Services.Configuration;
+
+public class AzureAdB2C
+{
+    public string Instance { get; set; }
+    public string ClientId { get; set; }
+    public string B2cExtensionAppClientId { get; set; }
+    public string Domain { get; set; }
+    public string SignUpSignInPolicyId { get; set; }
+    public string ClientSecret { get; set; }
+}

--- a/NRZMyk.Services/Configuration/AzureAdB2CSettings.cs
+++ b/NRZMyk.Services/Configuration/AzureAdB2CSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace NRZMyk.Services.Configuration
+{
+    public class AzureAdB2CSettings
+    {
+        public AzureAdB2C AzureAdB2C { get; set; }
+    }
+}

--- a/NRZMyk.Services/Data/Entities/RemoteAccount.cs
+++ b/NRZMyk.Services/Data/Entities/RemoteAccount.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Text;
 using NRZMyk.Services.Interfaces;
+using NRZMyk.Services.Models;
 
 namespace NRZMyk.Services.Data.Entities
 {
@@ -24,5 +26,8 @@ namespace NRZMyk.Services.Data.Entities
         public int? OrganizationId { get; set; }
 
         public Organization Organization { get; set; }
+
+        [NotMapped]
+        public Role Role { get; set; }
     }
 }

--- a/NRZMyk.Services/NRZMyk.Services.csproj
+++ b/NRZMyk.Services/NRZMyk.Services.csproj
@@ -13,5 +13,6 @@
     <PackageReference Include="SendGrid" Version="9.22.0" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
     <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.5" />
+    <PackageReference Include="Microsoft.Graph" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/NRZMyk.Services/Services/IGraphServiceClient.cs
+++ b/NRZMyk.Services/Services/IGraphServiceClient.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.Graph;
+
+namespace NRZMyk.Services.Services;
+
+public interface IGraphServiceClient
+{
+    IGraphServiceUsersCollectionRequestBuilder Users { get; }
+}

--- a/NRZMyk.Services/Services/IUserService.cs
+++ b/NRZMyk.Services/Services/IUserService.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Models;
+
+namespace NRZMyk.Services.Services;
+
+public interface IUserService
+{
+    Task UpdateRoleViaGraphApi(IEnumerable<RemoteAccount> remoteAccounts);
+    Task UpdateUserRole(string userId, Role role);
+}

--- a/NRZMyk.Services/Services/IUserService.cs
+++ b/NRZMyk.Services/Services/IUserService.cs
@@ -7,6 +7,6 @@ namespace NRZMyk.Services.Services;
 
 public interface IUserService
 {
-    Task UpdateRoleViaGraphApi(IEnumerable<RemoteAccount> remoteAccounts);
+    Task GetRolesViaGraphApi(IEnumerable<RemoteAccount> remoteAccounts);
     Task UpdateUserRole(string userId, Role role);
 }

--- a/NRZMyk.Services/Services/UserService.cs
+++ b/NRZMyk.Services/Services/UserService.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Graph;
+using NRZMyk.Services.Configuration;
+using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Models;
+using NRZMyk.Services.Utils;
+
+namespace NRZMyk.Services.Services;
+
+public class UserService : IUserService
+{
+    private readonly IGraphServiceClient _graphClient;
+    private readonly ILogger<UserService> _logger;
+    private readonly string _extensionAppClientId;
+
+    public UserService(IGraphServiceClient graphClient, IOptions<AzureAdB2CSettings> config, ILogger<UserService> logger)
+    {
+        if (string.IsNullOrWhiteSpace(config?.Value?.AzureAdB2C?.B2cExtensionAppClientId))
+        {
+            throw new ArgumentException(
+                "B2C Extension App ClientId (ApplicationId) is missing in the appsettings.json.",
+                nameof(_extensionAppClientId));
+        }
+
+        _graphClient = graphClient;
+        _logger = logger;
+        _extensionAppClientId = config.Value.AzureAdB2C.B2cExtensionAppClientId;
+    }
+
+    public async Task UpdateRoleViaGraphApi(IEnumerable<RemoteAccount> remoteAccounts)
+    {
+        var roleAttributeName = GetCompleteAttributeName("Role");
+
+        foreach (var remoteAccount in remoteAccounts)
+        {
+            var role = Role.Guest;
+
+            try
+            {
+                var user = await _graphClient.Users[remoteAccount.ObjectId.ToString()]
+                    .Request()
+                    .Select($"id,displayName,{roleAttributeName}")
+                    .GetAsync();
+            
+                if (user.AdditionalData?[roleAttributeName] != null)
+                {
+                    var roleString = user.AdditionalData?[roleAttributeName].ToString();
+                    role = Enum.Parse<Role>(roleString);
+                }
+            }
+            catch (ServiceException e)
+            {
+                if (e.StatusCode == HttpStatusCode.NotFound)
+                {
+                    _logger.LogWarning("User with ID {0} was not found in AADB2C, assigning guest role",
+                        remoteAccount.ObjectId);
+                }
+                else
+                {
+                    _logger.LogError(e, "Failed to query user with ID {0} from AADB2C, assigning guest role",
+                        remoteAccount.ObjectId);
+                }
+            }
+
+            remoteAccount.Role = role;
+        }
+    }
+   
+    public async Task UpdateUserRole(string userId, Role role)
+    {
+
+        Console.WriteLine($"Looking for user with object ID '{userId}'...");
+
+        // Declare the names of the custom attributes
+        const string customAttributeName1 = "Role";
+
+        // Get the complete name of the custom attribute (Azure AD extension)
+        string roleAttributeName = GetCompleteAttributeName(customAttributeName1);
+
+        Console.WriteLine($"Create a user with the custom attributes '{customAttributeName1}'");
+
+        // Fill custom attributes
+        IDictionary<string, object> extensionInstance = new Dictionary<string, object>();
+        extensionInstance.Add(roleAttributeName, ((int)role).ToString());
+
+        var user = new Microsoft.Graph.User
+        {
+            AdditionalData = extensionInstance
+        };
+
+
+        try
+        {
+            // Update user by object ID
+            await _graphClient.Users[userId]
+                .Request()
+                .UpdateAsync(user);
+
+            Console.WriteLine($"User with object ID '{userId}' successfully updated.");
+        }
+        catch (Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine(ex.Message);
+            Console.ResetColor();
+        }
+    }
+
+    internal string GetCompleteAttributeName(string attributeName)
+    {
+        var sanitizedClientId = _extensionAppClientId.Replace("-", "");
+        if (string.IsNullOrWhiteSpace(attributeName))
+        {
+            throw new System.ArgumentException("Parameter cannot be null", nameof(attributeName));
+        }
+
+        return $"extension_{sanitizedClientId}_{attributeName}";
+    }
+}

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ to setup client and server apps according to this documentation:
 
 ### Server App
 
-Configure the following secretsthe server project:
+Configure the following secrets for the server project:
 
 ```shell
+cd NRZMyk.Server
 dotnet user-secrets set "AzureAdB2C:Domain" "Your ADB2C domain"
 dotnet user-secrets set "AzureAdB2C:ClientId" "Your server app client ID"
 dotnet user-secrets set "AzureAdB2C:SignUpSignInPolicyId" "Your signin policy name"
@@ -51,6 +52,8 @@ dotnet user-secrets set "Application:SendGridSenderEmail": "Address used to send
 dotnet user-secrets set "Application:SendGridDynamicTemplateId": "Sendgrid dynamic template id"
 dotnet user-secrets set "Application:AdministratorEmail": "Address of admin to receive registration requests"
 dotnet user-secrets set "SendGrid:ApiKey" "Sendgrid API key"
+dotnet user-secrets set "AzureAdB2C:ClientSecret" "Client secret for GraphAPI access"
+dotnet user-secrets set "AzureAdB2C:B2cExtensionAppClientId" "B2C extensions app client id"
 ```
 
 See also `appsettings.json` in server project.

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -5,6 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>opencover</Format>
+          <Exclude>[*]NRZMyk.Services.Data.Migrations*</Exclude>
         </Configuration>
       </DataCollector>
     </DataCollectors>


### PR DESCRIPTION
As of now all user role changes were done via a small admin tool.
This is not really useful as it requires to involve some console
affine users.

This is the first make role management part of the admin page.
Roles are listed now and will be editable next.
