### PR TITLE
Validate SamplingDate as mandatory (#92)

### DIFF
--- a/Api.Integration.Tests/Api.Integration.Tests.csproj
+++ b/Api.Integration.Tests/Api.Integration.Tests.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	    <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	    <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NRZMyk.Server\NRZMyk.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Api.Integration.Tests/ClientFactory.cs
+++ b/Api.Integration.Tests/ClientFactory.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Api.Integration.Tests;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using NRZMyk.Server;
+using NRZMyk.Services.Data;
+
+namespace PublicApiIntegrationTests
+{
+    public static class ClientFactory
+    {
+        private static readonly WebApplicationFactory<Program> _factory;
+
+        static ClientFactory()
+        {
+            _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddAuthentication(TestAuthHandler.AuthenticationScheme)
+                        .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                            TestAuthHandler.AuthenticationScheme, _ => { });
+
+                    var descriptor = services.SingleOrDefault(
+                        d => d.ServiceType ==
+                             typeof(DbContextOptions<ApplicationDbContext>));
+                    services.Remove(descriptor);
+
+                    services.AddDbContext<ApplicationDbContext>(options =>
+                    {
+                        options.UseInMemoryDatabase("InMemoryDbForTesting");
+                    });
+
+                    services.AddDbContext<ApplicationDbContext>(options =>
+                        options.UseInMemoryDatabase("ApplicationDbContext")
+                            .ConfigureWarnings(b => b.Ignore(InMemoryEventId.TransactionIgnoredWarning)));
+                });
+            });
+        }
+
+        public static HttpClient CreateClient()
+        {
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+            });
+            
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(TestAuthHandler.AuthenticationScheme);
+            return client;
+        }
+    }
+}

--- a/Api.Integration.Tests/SentinelEntries/CreateTests.cs
+++ b/Api.Integration.Tests/SentinelEntries/CreateTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Services;
+using NUnit.Framework;
+using PublicApiIntegrationTests;
+using Tynamix.ObjectFiller;
+
+namespace Api.Integration.Tests.SentinelEntries
+{
+    public class CreateTests
+    {
+        [Test]
+        public async Task WhenCreatingValidSentinelEntry_RespondsWithCreate()
+        {
+            var client = ClientFactory.CreateClient();
+            var request = CreateValidRequest();
+
+            var response = await client.PostAsJsonAsync("api/sentinel-entries", request).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+
+        [Test]
+        public async Task WhenCreatingWithMissingSamplingDate_RespondsWithBadRequest()
+        {
+            var client = ClientFactory.CreateClient();
+            var request = CreateValidRequest();
+            request.SamplingDate = null;
+
+            var response = await client.PostAsJsonAsync("api/sentinel-entries", request).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            var content = await response.Content.ReadAsStringAsync();
+            content.Should().Contain(nameof(SentinelEntryRequest.SamplingDate));
+        }
+
+        private SentinelEntryRequest CreateValidRequest()
+        {
+            var filler = new Filler<SentinelEntryRequest>();
+            var request = filler.Create();
+            request.Material = Material.CentralBloodCultureOther;
+            request.HospitalDepartment = HospitalDepartment.GeneralSurgery;
+            request.IdentifiedSpecies = Species.CandidaDubliniensis;
+            request.SpeciesIdentificationMethod = SpeciesIdentificationMethod.BBL;
+            return request;
+        }
+    }
+}

--- a/Api.Integration.Tests/Swagger/SwaggerTest.cs
+++ b/Api.Integration.Tests/Swagger/SwaggerTest.cs
@@ -1,0 +1,21 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using PublicApiIntegrationTests;
+
+namespace Api.Integration.Tests.Swagger
+{
+    public class SwaggerTests
+    {
+        [Test]
+        public async Task WhenAccessingIndex_ReturnsPage()
+        {
+            var client = ClientFactory.CreateClient();
+
+            var response = await client.GetAsync("swagger/index.html").ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+}

--- a/Api.Integration.Tests/TestAuthHandler.cs
+++ b/Api.Integration.Tests/TestAuthHandler.cs
@@ -1,0 +1,32 @@
+﻿using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Api.Integration.Tests;
+
+public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    internal const string AuthenticationScheme = "Test";
+
+    public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, 
+        ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+        : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[] { new Claim(NRZMyk.Services.Models.ClaimTypes.Organization, "1") };
+        var identity = new ClaimsIdentity(claims, AuthenticationScheme);
+        identity.AddClaim(new Claim(identity.RoleClaimType, "User"));
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, AuthenticationScheme);
+
+        var result = AuthenticateResult.Success(ticket);
+
+        return Task.FromResult(result);
+    }
+}

--- a/NRZMyk.Client/Program.cs
+++ b/NRZMyk.Client/Program.cs
@@ -21,8 +21,8 @@ builder.Services.AddScoped<IHttpClient, LoggingJsonHttpClient>();
 // Custom services start
 
 builder.Services.AddBlazorApplicationInsights();
-builder.Services.AddAutoMapper(typeof(SentinelEntryService).Assembly);
-builder.Services.AddTransient<SentinelEntryService, SentinelEntryServiceImpl>();
+builder.Services.AddAutoMapper(typeof(ISentinelEntryService).Assembly);
+builder.Services.AddTransient<ISentinelEntryService, SentinelEntryServiceImpl>();
 builder.Services.AddTransient<IAccountService, AccountService>();
 builder.Services.AddTransient<IClinicalBreakpointService, ClinicalBreakpointService>();
 builder.Services.AddTransient<IMicStepsService, MicStepsService>();

--- a/NRZMyk.Component.Playground/Startup.cs
+++ b/NRZMyk.Component.Playground/Startup.cs
@@ -29,11 +29,11 @@ namespace NRZMyk.Components.Playground
         public void ConfigureServices(IServiceCollection services)
         {
             services.Configure<BreakpointSettings>(Configuration);
-            services.AddAutoMapper(typeof(Startup).Assembly, typeof(SentinelEntryService).Assembly);
+            services.AddAutoMapper(typeof(Startup).Assembly, typeof(ISentinelEntryService).Assembly);
             services.AddRazorPages();
             services.AddServerSideBlazor();
             services.AddSingleton<IApplicationInsights, NullApplicationInsights>();
-            services.AddSingleton<SentinelEntryService, MockSentinelEntryServiceImpl>();
+            services.AddSingleton<ISentinelEntryService, MockSentinelEntryServiceImpl>();
             services.AddSingleton<IAccountService, MockAccountService>();
             services.AddSingleton<IClinicalBreakpointService, MockClinicalBreakpointService>();
             services.AddSingleton<IMicStepsService, MicStepsService>();

--- a/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CreateTests.cs
+++ b/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CreateTests.cs
@@ -28,7 +28,7 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
         private TestContext _context;
         private MockClinicalBreakpointService _mockClinicalBreakpointService;
         private MockMicStepsService _mockMicStepsService;
-        private SentinelEntryService _sentinelEntryService;
+        private ISentinelEntryService _sentinelEntryService;
 
         [SetUp]
         public void CreateComponent()
@@ -38,15 +38,15 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
             _mockMicStepsService = new MockMicStepsService();
 
             _context = new TestContext();
-            _context.Services.AddAutoMapper(typeof(SentinelEntryService).Assembly);
-            _context.Services.AddSingleton<SentinelEntryService, MockSentinelEntryServiceImpl>();
+            _context.Services.AddAutoMapper(typeof(ISentinelEntryService).Assembly);
+            _context.Services.AddSingleton<ISentinelEntryService, MockSentinelEntryServiceImpl>();
             _context.Services.AddSingleton<IClinicalBreakpointService>(_mockClinicalBreakpointService);
             _context.Services.AddSingleton<IMicStepsService>(_mockMicStepsService);
             _context.Services.AddScoped<AuthenticationStateProvider, MockAuthStateProvider>();
             _context.Services.AddScoped<SignOutSessionStateManager>();
             _context.Services.AddScoped(typeof(ILogger<>), typeof(NullLogger<>));
 
-            _sentinelEntryService = _context.Services.GetService<SentinelEntryService>();
+            _sentinelEntryService = _context.Services.GetService<ISentinelEntryService>();
         }
 
         [TearDown]

--- a/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CryoViewTests.cs
+++ b/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CryoViewTests.cs
@@ -19,19 +19,19 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
     {
         private TestContext _context;
         private IRenderedComponent<CryoView> _renderedComponent;
-        private SentinelEntryService _sentinelEntryService;
+        private ISentinelEntryService _sentinelEntryService;
 
         [SetUp]
         public void CreateComponent()
         {
             MockSentinelEntryServiceImpl.Delay = 0;
             _context = new TestContext();
-            _context.Services.AddAutoMapper(typeof(SentinelEntryService).Assembly);
-            _context.Services.AddSingleton<SentinelEntryService, MockSentinelEntryServiceImpl>();
+            _context.Services.AddAutoMapper(typeof(ISentinelEntryService).Assembly);
+            _context.Services.AddSingleton<ISentinelEntryService, MockSentinelEntryServiceImpl>();
             _context.Services.AddSingleton<IAccountService, MockAccountService>();
             _context.Services.AddScoped(typeof(ILogger<>), typeof(NullLogger<>));
              
-            _sentinelEntryService = _context.Services.GetService<SentinelEntryService>();
+            _sentinelEntryService = _context.Services.GetService<ISentinelEntryService>();
             _renderedComponent = CreateSut(_context);
         }
 

--- a/NRZMyk.Components.Tests/Pages/SentinelEntryPage/DeleteTests.cs
+++ b/NRZMyk.Components.Tests/Pages/SentinelEntryPage/DeleteTests.cs
@@ -16,7 +16,7 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
     public class DeleteTests
     {
         private TestContext _context;
-        private SentinelEntryService _sentinelEntryService;
+        private ISentinelEntryService _sentinelEntryService;
         private IRenderedComponent<Delete> _renderedComponent;
 
         [SetUp]
@@ -24,11 +24,11 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
         {
             MockSentinelEntryServiceImpl.Delay = 0;
             _context = new TestContext();
-            _context.Services.AddAutoMapper(typeof(SentinelEntryService).Assembly);
-            _context.Services.AddSingleton<SentinelEntryService, MockSentinelEntryServiceImpl>();
+            _context.Services.AddAutoMapper(typeof(ISentinelEntryService).Assembly);
+            _context.Services.AddSingleton<ISentinelEntryService, MockSentinelEntryServiceImpl>();
             _context.Services.AddScoped(typeof(ILogger<>), typeof(NullLogger<>));
              
-            _sentinelEntryService = _context.Services.GetService<SentinelEntryService>();
+            _sentinelEntryService = _context.Services.GetService<ISentinelEntryService>();
             _renderedComponent = CreateSut(_context);
         }
 

--- a/NRZMyk.Components/Pages/SentinelEntryPage/CreateBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/CreateBase.cs
@@ -27,7 +27,7 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
         private ILogger<CreateBase> Logger { get; set; } = default!;
 
         [Inject]
-        private SentinelEntryService SentinelEntryService { get; set; } = default!;
+        private ISentinelEntryService SentinelEntryService { get; set; } = default!;
 
         [Inject]
         protected IMicStepsService MicStepsService { get; set; } = default!;

--- a/NRZMyk.Components/Pages/SentinelEntryPage/CryoView.razor
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/CryoView.razor
@@ -1,7 +1,7 @@
 ﻿@namespace NRZMyk.Components.Pages.SentinelEntryPage
 @page "/cryo-view/sentinel-entries"
 @attribute [Authorize(Roles = nameof(Role.SuperUser))]
-@inject SentinelEntryService SentinelEntryService
+@inject ISentinelEntryService SentinelEntryService
 @using NRZMyk.Services.ModelExtensions
 @using NRZMyk.Services.Models
 @using NRZMyk.Services.Services

--- a/NRZMyk.Components/Pages/SentinelEntryPage/CryoViewBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/CryoViewBase.cs
@@ -12,7 +12,7 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
         private IAccountService AccountService { get; set; } = default!;
 
         [Inject]
-        private SentinelEntryService SentinelEntryService { get; set; } = default!;
+        private ISentinelEntryService SentinelEntryService { get; set; } = default!;
 
         [Inject]
         private ILogger<CryoViewBase> Logger { get; set; } = default!;

--- a/NRZMyk.Components/Pages/SentinelEntryPage/DeleteBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/DeleteBase.cs
@@ -12,7 +12,7 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
         private ILogger<CreateBase> Logger { get; set; } = default!;
 
         [Inject]
-        private SentinelEntryService SentinelEntryService { get; set; } = default!;
+        private ISentinelEntryService SentinelEntryService { get; set; } = default!;
 
         [Inject]
         private IMapper Mapper { get; set; } = default!;

--- a/NRZMyk.Components/Pages/SentinelEntryPage/DetailsBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/DetailsBase.cs
@@ -12,7 +12,7 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
         private ILogger<CreateBase> Logger { get; set; } = default!;
 
         [Inject]
-        private SentinelEntryService SentinelEntryService { get; set; } = default!;
+        private ISentinelEntryService SentinelEntryService { get; set; } = default!;
 
         [Parameter]
         public int Id { get; set; }

--- a/NRZMyk.Components/Pages/SentinelEntryPage/ExportButtonBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/ExportButtonBase.cs
@@ -10,7 +10,7 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
         internal IJSRuntime JsRuntime { get; set; } = default!;   
 
         [Inject]
-        internal  SentinelEntryService SentinelEntryService { get; set; } = default!;
+        internal  ISentinelEntryService SentinelEntryService { get; set; } = default!;
 
         internal bool DownloadInProgress { get; private set; }
         

--- a/NRZMyk.Components/Pages/SentinelEntryPage/List.razor
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/List.razor
@@ -1,7 +1,7 @@
 ﻿@namespace NRZMyk.Components.Pages.SentinelEntryPage
 @page "/sentinel-entries"
 @attribute [Authorize(Roles = nameof(Role.User))]
-@inject SentinelEntryService SentinelEntryService
+@inject ISentinelEntryService SentinelEntryService
 @using NRZMyk.Services.Data.Entities
 @using NRZMyk.Services.ModelExtensions
 @using NRZMyk.Services.Models

--- a/NRZMyk.Components/SharedComponents/Input/SelectEnumOrOtherBase.cs
+++ b/NRZMyk.Components/SharedComponents/Input/SelectEnumOrOtherBase.cs
@@ -22,7 +22,7 @@ namespace NRZMyk.Components.SharedComponents.Input
         protected List<string> OtherValues { get; private set; } = new List<string>();
 
         [Inject]
-        private SentinelEntryService SentinelEntryService { get; set; } = default!;
+        private ISentinelEntryService SentinelEntryService { get; set; } = default!;
 
         protected Guid DataListId { get; } = Guid.NewGuid();
 

--- a/NRZMyk.Mocks/MockServices/MockSentinelEntryServiceImpl.cs
+++ b/NRZMyk.Mocks/MockServices/MockSentinelEntryServiceImpl.cs
@@ -12,7 +12,7 @@ using NRZMyk.Services.Services;
 
 namespace NRZMyk.Mocks.MockServices
 {
-    public class MockSentinelEntryServiceImpl : SentinelEntryService
+    public class MockSentinelEntryServiceImpl : ISentinelEntryService
     {
         public static int Delay = 2000;
 

--- a/NRZMyk.Server/Startup.cs
+++ b/NRZMyk.Server/Startup.cs
@@ -42,7 +42,7 @@ namespace NRZMyk.Server
             ConfigureAzureAdB2C(services);
             ConfigureSwagger(services);
 
-            services.AddAutoMapper(typeof(Startup).Assembly, typeof(SentinelEntryService).Assembly);
+            services.AddAutoMapper(typeof(Startup).Assembly, typeof(ISentinelEntryService).Assembly);
 
             services.AddControllersWithViews();
                 // TODO looks nice in swagger but need to find a way on how to make JsonStringEnumConverter

--- a/NRZMyk.Services.Tests/Services/EfRepositoryTests.cs
+++ b/NRZMyk.Services.Tests/Services/EfRepositoryTests.cs
@@ -22,7 +22,7 @@ public class EfRepositoryTests
     public void SetUp()
     {
         var contextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseInMemoryDatabase("BloggingControllerTest")
+            .UseInMemoryDatabase("ApplicationDbContext")
             .ConfigureWarnings(b => b.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
 

--- a/NRZMyk.Services.Tests/Validation/SentinelEntryRequestValidationTests.cs
+++ b/NRZMyk.Services.Tests/Validation/SentinelEntryRequestValidationTests.cs
@@ -9,10 +9,10 @@ using NUnit.Framework;
 
 namespace NRZMyk.Services.Tests.Validation
 {
-    public class SensitivityTestNotEmptyWithoutCommentAttributeTests
+    public class SentinelEntryRequestValidationTests
     {
         [Test]
-        public void WhenIncorrectParentType_IsTreatedAsValid()
+        public void WhenIncorrectParentTypeForSensitivityTestNotEmptyWithoutComment_IsTreatedAsValid()
         {
             var target = new InvalidType();
             var context = new ValidationContext(target);
@@ -94,6 +94,23 @@ namespace NRZMyk.Services.Tests.Validation
             var result = results.SingleOrDefault(r =>
                 r.MemberNames.Contains(nameof(SentinelEntryRequest.AntimicrobialSensitivityTests)));
             result.Should().BeNull();
+        }
+
+        [Test]
+        public void WhenSamplingDateIsMissing_IsTreatedAsInvalid()
+        {
+            var target = new SentinelEntryRequest()
+            {
+                SamplingDate = null
+            };
+            var context = new ValidationContext(target);
+            var results = new List<ValidationResult>();
+            
+            Validator.TryValidateObject(target, context, results, true);
+
+            var result = results.SingleOrDefault(r =>
+                r.MemberNames.Contains(nameof(SentinelEntryRequest.SamplingDate)));
+            result.Should().NotBe(null, $"{nameof(SentinelEntryRequest.SamplingDate)} should be required");
         }
 
         private SensitivityTestNotEmptyWithoutCommentAttribute CreateSut()

--- a/NRZMyk.Services/Services/ISentinelEntryService.cs
+++ b/NRZMyk.Services/Services/ISentinelEntryService.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using NRZMyk.Services.Data.Entities;
+
+namespace NRZMyk.Services.Services;
+
+public interface ISentinelEntryService
+{
+    Task<SentinelEntry> Create(SentinelEntryRequest createRequest);
+    Task<List<SentinelEntry>> ListPaged(int pageSize);
+    Task<List<SentinelEntry>> ListByOrganization(int organizationId);
+    Task<SentinelEntry> GetById(int id);
+    Task<SentinelEntry> Update(SentinelEntryRequest updateRequest);
+    Task<SentinelEntry> CryoArchive(CryoArchiveRequest archiveRequest);
+    Task<string> Export();
+    Task<List<string>> Other(string other);
+    Task Delete(int id);
+}

--- a/NRZMyk.Services/Services/SentinelEntryRequest.cs
+++ b/NRZMyk.Services/Services/SentinelEntryRequest.cs
@@ -11,6 +11,7 @@ namespace NRZMyk.Services.Services
     {
         public int Id { get; set; }
 
+        [Required(ErrorMessage = "Das Feld \"Probenentnahme\" ist erforderlich")]
         public DateTime? SamplingDate { get; set; }
 
         [Required(ErrorMessage = "Das Feld Labornummer Einsender ist erforderlich")]

--- a/NRZMyk.Services/Services/SentinelEntryService.cs
+++ b/NRZMyk.Services/Services/SentinelEntryService.cs
@@ -4,20 +4,7 @@ using NRZMyk.Services.Data.Entities;
 
 namespace NRZMyk.Services.Services
 {
-    public interface SentinelEntryService
-    {
-        Task<SentinelEntry> Create(SentinelEntryRequest createRequest);
-        Task<List<SentinelEntry>> ListPaged(int pageSize);
-        Task<List<SentinelEntry>> ListByOrganization(int organizationId);
-        Task<SentinelEntry> GetById(int id);
-        Task<SentinelEntry> Update(SentinelEntryRequest updateRequest);
-        Task<SentinelEntry> CryoArchive(CryoArchiveRequest archiveRequest);
-        Task<string> Export();
-        Task<List<string>> Other(string other);
-        Task Delete(int id);
-    }
-
-    public class SentinelEntryServiceImpl : SentinelEntryService
+    public class SentinelEntryServiceImpl : ISentinelEntryService
     {
         private const string BaseApi = "api/sentinel-entries";
         private readonly IHttpClient _httpClient;

--- a/NRZMyk.sln
+++ b/NRZMyk.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29728.190
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NRZMyk.Components", "NRZMyk.Components\NRZMyk.Components.csproj", "{45828280-23BD-4C6A-8799-FF5CF7B245C5}"
 EndProject
@@ -26,6 +26,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NRZMyk.Services.Tests", "NRZMyk.Services.Tests\NRZMyk.Services.Tests.csproj", "{583D3A86-3C9E-4BC4-B026-37F87DE939A1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NRZMyk.Server.Tests", "NRZMyk.Server.Tests\NRZMyk.Server.Tests.csproj", "{83803D33-290B-4B66-8DE2-A9AC49A1F8DC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Api.Integration.Tests", "Api.Integration.Tests\Api.Integration.Tests.csproj", "{4177D798-2211-441C-A8BB-9B8671B353EC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +71,10 @@ Global
 		{83803D33-290B-4B66-8DE2-A9AC49A1F8DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{83803D33-290B-4B66-8DE2-A9AC49A1F8DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{83803D33-290B-4B66-8DE2-A9AC49A1F8DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4177D798-2211-441C-A8BB-9B8671B353EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4177D798-2211-441C-A8BB-9B8671B353EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4177D798-2211-441C-A8BB-9B8671B353EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4177D798-2211-441C-A8BB-9B8671B353EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Database model not changed in order to to conflict with legacy data.
Add integration test to ensure API is respecting validations as well.

(Interface rename for ISentinelEntryService sneaked in this commit)
