### PR TITLE
Marks entry as follow-up (#90)

### DIFF
--- a/Api.Integration.Tests/Api.Integration.Tests.csproj
+++ b/Api.Integration.Tests/Api.Integration.Tests.csproj
@@ -24,8 +24,8 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Api.Integration.Tests/SentinelEntries/CreateTests.cs
+++ b/Api.Integration.Tests/SentinelEntries/CreateTests.cs
@@ -20,8 +20,77 @@ namespace Api.Integration.Tests.SentinelEntries
             var request = CreateValidRequest();
 
             var response = await client.PostAsJsonAsync("api/sentinel-entries", request).ConfigureAwait(true);
-
+            var createdEntryPath = response.Headers.Location?.AbsolutePath;
+            var test = await client.GetAsync(createdEntryPath);
+            var createdEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(createdEntryPath).ConfigureAwait(true);
+            
+            createdEntry.Id.Should().BeGreaterThan(0);
             response.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+
+        [Test]
+        public async Task WhenCreatingWithValidPredecessorEntry_RespondsWithCreate()
+        {
+            var client = ClientFactory.CreateClient();
+            var predecessor = CreateValidRequest();
+
+            var predecessorResponse = await client.PostAsJsonAsync("api/sentinel-entries", predecessor).ConfigureAwait(true);
+            var predecessorPath = predecessorResponse.Headers.Location?.AbsolutePath;
+            var predecessorEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(predecessorPath).ConfigureAwait(true);
+            predecessorEntry.Id.Should().BeGreaterThan(0);
+            
+            //Follow-up entry
+            var followUp = CreateValidRequest();
+            followUp.PredecessorLaboratoryNumber = predecessorEntry.LaboratoryNumber;
+            var followUpResponse = await client.PostAsJsonAsync("api/sentinel-entries", followUp).ConfigureAwait(true);
+            var followUpPath = followUpResponse.Headers.Location?.AbsolutePath;
+            var followUpEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(followUpPath).ConfigureAwait(true);
+
+            followUpEntry.PredecessorLaboratoryNumber.Should().Be(predecessorEntry.LaboratoryNumber);
+        }
+
+        
+        [Test]
+        public async Task WhenCreatingPredecessorCircle_RespondsWithCreate()
+        {
+            var client = ClientFactory.CreateClient();
+            var predecessor = CreateValidRequest();
+
+            // Arrange: Create entry with follow-up
+            var predecessorResponse = await client.PostAsJsonAsync("api/sentinel-entries", predecessor).ConfigureAwait(true);
+            var predecessorPath = predecessorResponse.Headers.Location?.AbsolutePath;
+            var predecessorEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(predecessorPath).ConfigureAwait(true);
+            predecessorEntry.Id.Should().BeGreaterThan(0);
+            var followUp = CreateValidRequest();
+            followUp.PredecessorLaboratoryNumber = predecessorEntry.LaboratoryNumber;
+            var followUpResponse = await client.PostAsJsonAsync("api/sentinel-entries", followUp).ConfigureAwait(true);
+            var followUpPath = followUpResponse.Headers.Location?.AbsolutePath;
+            var followUpEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(followUpPath).ConfigureAwait(true);
+
+            // Arrange: Make original entry reference follow-up, thus creating a circle
+            predecessor.Id = predecessorEntry.Id;
+            predecessor.PredecessorLaboratoryNumber = followUpEntry.LaboratoryNumber;
+            
+            var circleResponse = await client.PutAsJsonAsync("api/sentinel-entries", predecessor).ConfigureAwait(true);
+            
+            circleResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            predecessorEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(predecessorPath).ConfigureAwait(true);
+            predecessorEntry.PredecessorLaboratoryNumber.Should().Be(followUpEntry.LaboratoryNumber);
+        }
+
+        [Test]
+        public async Task WhenCreatingUnknownPredecessorEntry_RespondsWithBadRequest()
+        {
+            var client = ClientFactory.CreateClient();
+            var request = CreateValidRequest();
+            request.PredecessorLaboratoryNumber = "SN-4242-0042";
+
+            var response = await client.PostAsJsonAsync("api/sentinel-entries", request).ConfigureAwait(true);
+            
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            var content = await response.Content.ReadAsStringAsync();
+            content.Should().Contain("PredecessorLaboratoryNumber");
+            content.Should().Contain("Laboratory number can not be found");
         }
 
         [Test]
@@ -61,6 +130,8 @@ namespace Api.Integration.Tests.SentinelEntries
             request.IdentifiedSpecies = Species.CandidaDubliniensis;
             request.SpeciesIdentificationMethod = SpeciesIdentificationMethod.BBL;
             request.SamplingDate = DateTime.Now.AddDays(-3);
+            request.PredecessorLaboratoryNumber = string.Empty;
+            request.HasPredecessor = YesNo.No;
             return request;
         }
     }

--- a/Api.Integration.Tests/SentinelEntries/CreateTests.cs
+++ b/Api.Integration.Tests/SentinelEntries/CreateTests.cs
@@ -40,7 +40,7 @@ namespace Api.Integration.Tests.SentinelEntries
             
             //Follow-up entry
             var followUp = CreateValidRequest();
-            followUp.PredecessorLaboratoryNumber = predecessorEntry.LaboratoryNumber;
+            followUp.PredecessorLaboratoryNumber = predecessorEntry?.LaboratoryNumber;
             var followUpResponse = await client.PostAsJsonAsync("api/sentinel-entries", followUp).ConfigureAwait(true);
             var followUpPath = followUpResponse.Headers.Location?.AbsolutePath;
             var followUpEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(followUpPath).ConfigureAwait(true);
@@ -59,22 +59,24 @@ namespace Api.Integration.Tests.SentinelEntries
             var predecessorResponse = await client.PostAsJsonAsync("api/sentinel-entries", predecessor).ConfigureAwait(true);
             var predecessorPath = predecessorResponse.Headers.Location?.AbsolutePath;
             var predecessorEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(predecessorPath).ConfigureAwait(true);
+            predecessorEntry.Should().NotBeNull();
             predecessorEntry?.Id.Should().BeGreaterThan(0);
             var followUp = CreateValidRequest();
-            followUp.PredecessorLaboratoryNumber = predecessorEntry.LaboratoryNumber;
+            followUp.PredecessorLaboratoryNumber = predecessorEntry?.LaboratoryNumber;
             var followUpResponse = await client.PostAsJsonAsync("api/sentinel-entries", followUp).ConfigureAwait(true);
             var followUpPath = followUpResponse.Headers.Location?.AbsolutePath;
             var followUpEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(followUpPath).ConfigureAwait(true);
+            followUpEntry.Should().NotBeNull();
 
             // Arrange: Make original entry reference follow-up, thus creating a circle
             predecessor.Id = predecessorEntry.Id;
-            predecessor.PredecessorLaboratoryNumber = followUpEntry.LaboratoryNumber;
+            predecessor.PredecessorLaboratoryNumber = followUpEntry?.LaboratoryNumber;
             
             var circleResponse = await client.PutAsJsonAsync("api/sentinel-entries", predecessor).ConfigureAwait(true);
             
             circleResponse.StatusCode.Should().Be(HttpStatusCode.OK);
             predecessorEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(predecessorPath).ConfigureAwait(true);
-            predecessorEntry?.PredecessorLaboratoryNumber.Should().Be(followUpEntry.LaboratoryNumber);
+            predecessorEntry?.PredecessorLaboratoryNumber.Should().Be(followUpEntry?.LaboratoryNumber);
         }
 
         [Test]

--- a/Api.Integration.Tests/SentinelEntries/CreateTests.cs
+++ b/Api.Integration.Tests/SentinelEntries/CreateTests.cs
@@ -21,10 +21,9 @@ namespace Api.Integration.Tests.SentinelEntries
 
             var response = await client.PostAsJsonAsync("api/sentinel-entries", request).ConfigureAwait(true);
             var createdEntryPath = response.Headers.Location?.AbsolutePath;
-            var test = await client.GetAsync(createdEntryPath);
             var createdEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(createdEntryPath).ConfigureAwait(true);
             
-            createdEntry.Id.Should().BeGreaterThan(0);
+            createdEntry?.Id.Should().BeGreaterThan(0);
             response.StatusCode.Should().Be(HttpStatusCode.Created);
         }
 
@@ -37,7 +36,7 @@ namespace Api.Integration.Tests.SentinelEntries
             var predecessorResponse = await client.PostAsJsonAsync("api/sentinel-entries", predecessor).ConfigureAwait(true);
             var predecessorPath = predecessorResponse.Headers.Location?.AbsolutePath;
             var predecessorEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(predecessorPath).ConfigureAwait(true);
-            predecessorEntry.Id.Should().BeGreaterThan(0);
+            predecessorEntry?.Id.Should().BeGreaterThan(0);
             
             //Follow-up entry
             var followUp = CreateValidRequest();
@@ -46,7 +45,7 @@ namespace Api.Integration.Tests.SentinelEntries
             var followUpPath = followUpResponse.Headers.Location?.AbsolutePath;
             var followUpEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(followUpPath).ConfigureAwait(true);
 
-            followUpEntry.PredecessorLaboratoryNumber.Should().Be(predecessorEntry.LaboratoryNumber);
+            followUpEntry?.PredecessorLaboratoryNumber.Should().Be(predecessorEntry.LaboratoryNumber);
         }
 
         
@@ -60,7 +59,7 @@ namespace Api.Integration.Tests.SentinelEntries
             var predecessorResponse = await client.PostAsJsonAsync("api/sentinel-entries", predecessor).ConfigureAwait(true);
             var predecessorPath = predecessorResponse.Headers.Location?.AbsolutePath;
             var predecessorEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(predecessorPath).ConfigureAwait(true);
-            predecessorEntry.Id.Should().BeGreaterThan(0);
+            predecessorEntry?.Id.Should().BeGreaterThan(0);
             var followUp = CreateValidRequest();
             followUp.PredecessorLaboratoryNumber = predecessorEntry.LaboratoryNumber;
             var followUpResponse = await client.PostAsJsonAsync("api/sentinel-entries", followUp).ConfigureAwait(true);
@@ -75,7 +74,7 @@ namespace Api.Integration.Tests.SentinelEntries
             
             circleResponse.StatusCode.Should().Be(HttpStatusCode.OK);
             predecessorEntry = await client.GetFromJsonAsync<SentinelEntryResponse>(predecessorPath).ConfigureAwait(true);
-            predecessorEntry.PredecessorLaboratoryNumber.Should().Be(followUpEntry.LaboratoryNumber);
+            predecessorEntry?.PredecessorLaboratoryNumber.Should().Be(followUpEntry.LaboratoryNumber);
         }
 
         [Test]
@@ -88,7 +87,7 @@ namespace Api.Integration.Tests.SentinelEntries
             var response = await client.PostAsJsonAsync("api/sentinel-entries", request).ConfigureAwait(true);
             
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-            var content = await response.Content.ReadAsStringAsync();
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
             content.Should().Contain("PredecessorLaboratoryNumber");
             content.Should().Contain("Laboratory number can not be found");
         }

--- a/NRZMyk.Client/NRZMyk.Client.csproj
+++ b/NRZMyk.Client/NRZMyk.Client.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="BlazorApplicationInsights" Version="1.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="6.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>

--- a/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CryoViewTests.cs
+++ b/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CryoViewTests.cs
@@ -76,7 +76,7 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
 
             _renderedComponent.Markup.Should().Contain("Duplicate to SN-133422");
             var entry = await _sentinelEntryService.GetById(1).ConfigureAwait(true);
-            entry.CryoDate.Should().BeCloseTo(DateTime.Now);
+            entry.CryoDate.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(2));
         }
         
         [Test]

--- a/NRZMyk.Components/NRZMyk.Components.csproj
+++ b/NRZMyk.Components/NRZMyk.Components.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="BlazorApplicationInsights" Version="1.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="6.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />

--- a/NRZMyk.Components/Pages/SentinelEntryPage/Create.razor
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/Create.razor
@@ -64,7 +64,11 @@ else
                     <ValidationMessage For="() => SentinelEntry.Remark"/>
                 </div>
             </div>
-
+            
+            <SelectEnumOrOther Label="Folgeisolat" Key="laboratory-numbers" Other="YesNo.Yes" OtherLabel="Labornummer Vorgänger"
+                               @bind-OtherValue="@SentinelEntry.PredecessorLaboratoryNumber" @bind-Value="@SentinelEntry.HasPredecessor"
+                               ValidationFor="() => SentinelEntry.HasPredecessor" ValidationForOther="() => SentinelEntry.PredecessorLaboratoryNumber"/>
+            
             <h3>Tests</h3>
             <div class="mb-3 row">
                 <div class="col-sm-3 col-lg-2">

--- a/NRZMyk.Components/Pages/SentinelEntryPage/CreateBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/CreateBase.cs
@@ -259,7 +259,7 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
 
             if (Id.HasValue)
             {
-                SentinelEntry = Mapper.Map<SentinelEntryRequest>(await SentinelEntryService.GetById(Id.Value).ConfigureAwait(true));
+                SentinelEntry = await SentinelEntryService.GetById(Id.Value).ConfigureAwait(true);
             }
             else
             {

--- a/NRZMyk.Components/Pages/SentinelEntryPage/DetailsBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/DetailsBase.cs
@@ -20,7 +20,7 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
         [Parameter]
         public EventCallback<string> OnCloseClick { get; set; }
 
-        internal SentinelEntry SentinelEntry { get; set; } = default!;
+        internal SentinelEntryResponse SentinelEntry { get; set; } = default!;
 
         protected override async Task OnInitializedAsync()
         {

--- a/NRZMyk.Mocks/MockServices/MockSentinelEntryServiceImpl.cs
+++ b/NRZMyk.Mocks/MockServices/MockSentinelEntryServiceImpl.cs
@@ -92,10 +92,10 @@ namespace NRZMyk.Mocks.MockServices
                 : _repository.Where(s => s.ProtectKey == organizationId.ToString()).ToList();
         }
 
-        public async Task<SentinelEntry> GetById(int id)
+        public async Task<SentinelEntryResponse> GetById(int id)
         {
             await Task.Delay(Delay);
-            return _repository.FirstOrDefault(e => e.Id == id);
+            return _mapper.Map<SentinelEntryResponse>(_repository.FirstOrDefault(e => e.Id == id));
         }
 
         public Task<SentinelEntry> Update(SentinelEntryRequest updateRequest)

--- a/NRZMyk.Mocks/NRZMyk.Mocks.csproj
+++ b/NRZMyk.Mocks/NRZMyk.Mocks.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.5" />
   </ItemGroup>

--- a/NRZMyk.Server.Tests/Controllers/SentinelEntries/CreateTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/SentinelEntries/CreateTests.cs
@@ -34,6 +34,20 @@ namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
             await repository.Received(0).AddAsync(sentinelEntry).ConfigureAwait(true);
         }
 
+
+        [Test]
+        public async Task WhenCreatedWithInvalidPredecessorNumber_BadRequest()
+        {
+            var sut = CreateSut(out var repository, out var mapper, "12");
+            var createSentinelEntryRequest = new SentinelEntryRequest() { PredecessorLaboratoryNumber = "SN-3022-0001"};
+            var sentinelEntry = new SentinelEntry {Id = 123};
+
+            var action = await sut.HandleAsync(createSentinelEntryRequest).ConfigureAwait(true);
+            
+            action.Result.Should().BeOfType<BadRequestObjectResult>();
+            await repository.Received(0).AddAsync(sentinelEntry).ConfigureAwait(true);
+        }
+
         [Test]
         public async Task WhenCreated_MapsAndStoresToRepository()
         {
@@ -50,6 +64,27 @@ namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
             var createdResult = action.Result.Should().BeOfType<CreatedResult>().Subject;
             createdResult.Value.Should().Be(sentinelEntry);
             createdResult.Location.Should().Be("http://localhost/api/sentinel-entries/123");
+        }
+
+        [Test]
+        public async Task WhenCreatedWithValidPredecessor_StoresRelationToRepository()
+        {
+            SentinelEntry createdEntry = null;
+            var sut = CreateSut(out var repository, out var mapper, "12");
+            var createSentinelEntryRequest = new SentinelEntryRequest {PredecessorLaboratoryNumber = "SN-2022-0001"};
+            var sentinelEntry = new SentinelEntry {Id = 124};
+            var predecessorSentinelEntry = new SentinelEntry {Id = 100};
+            mapper.Map<SentinelEntry>(createSentinelEntryRequest).Returns(sentinelEntry);
+            repository.When(r => r.AddAsync(Arg.Any<SentinelEntry>())).Do(call => createdEntry = call.Arg<SentinelEntry>());
+            repository.AddAsync(sentinelEntry).Returns(sentinelEntry);
+            repository.FirstOrDefaultAsync(Arg.Any<SentinelEntryByLaboratoryNumberSpecification>()).Returns(predecessorSentinelEntry);
+
+            var action = await sut.HandleAsync(createSentinelEntryRequest).ConfigureAwait(true);
+
+            await repository.Received(1).FirstOrDefaultAsync(Arg.Is<SentinelEntryByLaboratoryNumberSpecification>(
+                s => s.Year == 2022 && s.SequentialNumber == 1 && s.ProtectKey == "12")).ConfigureAwait(true);
+            createdEntry.PredecessorEntryId.Should().Be(100);
+            var createdResult = action.Result.Should().BeOfType<CreatedResult>().Subject;
         }
 
         private static Create CreateSut(out ISentinelEntryRepository sentinelEntryRepository, out IMapper map, string organizationId = null)

--- a/NRZMyk.Server.Tests/Controllers/SentinelEntries/OtherLaboratoryNumbersTests.cs
+++ b/NRZMyk.Server.Tests/Controllers/SentinelEntries/OtherLaboratoryNumbersTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NRZMyk.Mocks.TestUtils;
+using NRZMyk.Server.Controllers.SentinelEntries;
+using NRZMyk.Services.Data;
+using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Interfaces;
+using NRZMyk.Services.Specifications;
+using NSubstitute;
+using NUnit.Framework;
+using Tynamix.ObjectFiller;
+
+namespace NRZMyk.Server.Tests.Controllers.SentinelEntries
+{
+    public class OtherLaboratoryNumbersTests
+    {
+        private readonly Filler<SentinelEntry> _filler = new();
+
+        [Test]
+        public async Task WhenEntriesExist_ReturnsLaboratoryNumbers()
+        {
+            var sut = CreateSut(out var repository, "567");
+            var entries = _filler.Create(3);
+            var sequentialNumber = 50;
+            foreach (var entry in entries)
+            {
+                entry.YearlySequentialEntryNumber = sequentialNumber--;
+                entry.Year = 2007;
+            }
+            repository.ListAsync(Arg.Is<SentinelEntryFilterSpecification>(specification => specification.ProtectKey == "567"))
+                .Returns(Task.FromResult((IReadOnlyList<SentinelEntry>)entries));
+
+            var action = await sut.HandleAsync().ConfigureAwait(true);
+
+            action.Result.Should().BeOfType<OkObjectResult>();
+            var laboratoryNumbers = action.Result.As<OkObjectResult>().Value.As<List<string>>();
+            laboratoryNumbers.Should().NotBeNull();
+            laboratoryNumbers.Should().ContainInOrder(
+                "SN-2007-0048", "SN-2007-0049", "SN-2007-0050");
+        }
+
+        [Test]
+        public async Task WhenNoEntryFound_ReturnsEmptyList()
+        {
+            var sut = CreateSut(out var repository, "567");
+            var entries = new List<SentinelEntry>();
+            repository.ListAsync(Arg.Is<SentinelEntryFilterSpecification>(specification => specification.ProtectKey == "567"))
+                .Returns(Task.FromResult((IReadOnlyList<SentinelEntry>)entries));
+
+            var action = await sut.HandleAsync().ConfigureAwait(true);
+
+            action.Result.Should().BeOfType<OkObjectResult>();
+            action.Result.As<OkObjectResult>().Value.As<List<string>>().Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task WhenNoOrganization_AccessDenied()
+        {
+            var sut = CreateSut(out var repository, "");
+
+            var action = await sut.HandleAsync().ConfigureAwait(true);
+
+            action.Result.Should().BeOfType<ForbidResult>();
+            await repository.Received(0).ListAsync(Arg.Any<SentinelEntryFilterSpecification>()).ConfigureAwait(true);
+        }
+
+        private static OtherLaboratoryNumbers CreateSut(out ISentinelEntryRepository repository, string organizationId)
+        {
+            repository = Substitute.For<ISentinelEntryRepository>();
+            return new OtherLaboratoryNumbers(repository)
+            {
+                ControllerContext = new MockControllerContext(organizationId:organizationId)
+            };
+        }
+    }
+}

--- a/NRZMyk.Server/Controllers/SentinelEntries/Create.cs
+++ b/NRZMyk.Server/Controllers/SentinelEntries/Create.cs
@@ -23,7 +23,6 @@ namespace NRZMyk.Server.Controllers.SentinelEntries
     {
         private readonly ISentinelEntryRepository _sentinelEntryRepository;
         private readonly IMapper _mapper;
-        private readonly IOptions<ApiBehaviorOptions> _apiBehaviorOptions;
 
         public string OrganizationId => User.Claims.OrganizationId();
 
@@ -61,12 +60,6 @@ namespace NRZMyk.Server.Controllers.SentinelEntries
 
             var storedEntry = await _sentinelEntryRepository.AddAsync(newEntry).ConfigureAwait(false);
             return Created(new Uri($"{Request.GetUri()}/{storedEntry.Id}"), storedEntry);
-        }
-
-        private class Error
-        {
-            public string ErrorField { get; set; }
-            public string ErrorDescription { get; set; }
         }
     }
 }

--- a/NRZMyk.Server/Controllers/SentinelEntries/Create.cs
+++ b/NRZMyk.Server/Controllers/SentinelEntries/Create.cs
@@ -1,15 +1,18 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Ardalis.ApiEndpoints;
 using AutoMapper;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using NRZMyk.Services.Data;
 using NRZMyk.Services.Data.Entities;
 using NRZMyk.Services.Interfaces;
 using NRZMyk.Services.Models;
 using NRZMyk.Services.Services;
+using NRZMyk.Services.Specifications;
 using NRZMyk.Services.Utils;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -20,6 +23,9 @@ namespace NRZMyk.Server.Controllers.SentinelEntries
     {
         private readonly ISentinelEntryRepository _sentinelEntryRepository;
         private readonly IMapper _mapper;
+        private readonly IOptions<ApiBehaviorOptions> _apiBehaviorOptions;
+
+        public string OrganizationId => User.Claims.OrganizationId();
 
         public Create(ISentinelEntryRepository sentinelEntryRepository, IMapper mapper)
         {
@@ -33,19 +39,34 @@ namespace NRZMyk.Server.Controllers.SentinelEntries
             OperationId = "catalog-entries.create",
             Tags = new[] { "SentinelEndpoints" })
         ]
-        public override async Task<ActionResult<SentinelEntry>> HandleAsync(SentinelEntryRequest request)
+        public override async Task<ActionResult<SentinelEntry>> HandleAsync(SentinelEntryRequest request )
         {
-            var organizationId = User.Claims.OrganizationId();
-            if (string.IsNullOrEmpty(organizationId))
+            if (string.IsNullOrEmpty(OrganizationId))
             {
                 return Forbid();
             }
+
+      
             var newEntry = _mapper.Map<SentinelEntry>(request);
+
+            var error = await Utils.ResolvePredecessor(request, newEntry, _sentinelEntryRepository, OrganizationId, ModelState).ConfigureAwait(false);
+            if (error)
+            {
+                return new BadRequestObjectResult(ModelState);
+            }
+
             _sentinelEntryRepository.AssignNextEntryNumber(newEntry);
             _sentinelEntryRepository.AssignNextCryoBoxNumber(newEntry);
-            newEntry.ProtectKey = organizationId;
+            newEntry.ProtectKey = OrganizationId;
+
             var storedEntry = await _sentinelEntryRepository.AddAsync(newEntry).ConfigureAwait(false);
             return Created(new Uri($"{Request.GetUri()}/{storedEntry.Id}"), storedEntry);
+        }
+
+        private class Error
+        {
+            public string ErrorField { get; set; }
+            public string ErrorDescription { get; set; }
         }
     }
 }

--- a/NRZMyk.Server/Controllers/SentinelEntries/GetById.cs
+++ b/NRZMyk.Server/Controllers/SentinelEntries/GetById.cs
@@ -1,10 +1,12 @@
 ﻿using System.Threading.Tasks;
 using Ardalis.ApiEndpoints;
+using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NRZMyk.Services.Data.Entities;
 using NRZMyk.Services.Interfaces;
 using NRZMyk.Services.Models;
+using NRZMyk.Services.Services;
 using NRZMyk.Services.Specifications;
 using NRZMyk.Services.Utils;
 using Swashbuckle.AspNetCore.Annotations;
@@ -12,13 +14,15 @@ using Swashbuckle.AspNetCore.Annotations;
 namespace NRZMyk.Server.Controllers.SentinelEntries
 {
     [Authorize(Roles = nameof(Role.User))]
-    public class GetById : BaseAsyncEndpoint<int, SentinelEntry>
+    public class GetById : BaseAsyncEndpoint<int, SentinelEntryResponse>
     {
         private readonly IAsyncRepository<SentinelEntry> _sentinelEntryRepository;
+        private readonly IMapper _mapper;
 
-        public GetById(IAsyncRepository<SentinelEntry> sentinelEntryRepository)
+        public GetById(IAsyncRepository<SentinelEntry> sentinelEntryRepository, IMapper mapper)
         {
             _sentinelEntryRepository = sentinelEntryRepository;
+            _mapper = mapper;
         }
 
         [HttpGet("api/sentinel-entries/{sentinelEntryId}")]
@@ -27,7 +31,7 @@ namespace NRZMyk.Server.Controllers.SentinelEntries
             OperationId = "sentinel-entries.GetById",
             Tags = new[] { "SentinelEndpoints" })
         ]
-        public override async Task<ActionResult<SentinelEntry>> HandleAsync([FromRoute] int sentinelEntryId)
+        public override async Task<ActionResult<SentinelEntryResponse>> HandleAsync([FromRoute] int sentinelEntryId)
         {
             var organizationId = User.Claims.OrganizationId();
             if (string.IsNullOrEmpty(organizationId))
@@ -41,7 +45,7 @@ namespace NRZMyk.Server.Controllers.SentinelEntries
                 return NotFound();
             }
 
-            return Ok(sentinelEntry);
+            return Ok(_mapper.Map<SentinelEntryResponse>(sentinelEntry));
         }
     }
 }

--- a/NRZMyk.Server/Controllers/SentinelEntries/OtherLaboratoryNumbers.cs
+++ b/NRZMyk.Server/Controllers/SentinelEntries/OtherLaboratoryNumbers.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Ardalis.ApiEndpoints;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NRZMyk.Services.Configuration;
+using NRZMyk.Services.Data;
+using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Models;
+using NRZMyk.Services.Specifications;
+using NRZMyk.Services.Utils;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace NRZMyk.Server.Controllers.SentinelEntries
+{
+    [Authorize(Roles = nameof(Role.User))]
+    public class OtherLaboratoryNumbers : BaseAsyncEndpoint<List<string>>
+    {
+        private readonly ISentinelEntryRepository _sentinelEntryRepository;
+
+        public OtherLaboratoryNumbers(ISentinelEntryRepository sentinelEntryRepository, IOptions<ApplicationSettings> config)
+        {
+            _sentinelEntryRepository = sentinelEntryRepository;
+        }
+
+        [HttpGet("api/sentinel-entries/other/laboratory-numbers")]
+        [SwaggerOperation(
+            Summary = "List all used other laboratory numbers)",
+            OperationId = "sentinel-entries.OtherLaboratoryNumbers",
+            Tags = new[] { "SentinelEndpoints" })
+        ]
+        public override async Task<ActionResult<List<string>>> HandleAsync()
+        {
+
+            var organizationId = User.Claims.OrganizationId();
+            if (string.IsNullOrEmpty(organizationId))
+            {
+                return Forbid();
+            }
+
+            var response = new ListPagedSentinelEntryResponse();
+
+            var entriesForOrganization = await _sentinelEntryRepository.ListAsync(new SentinelEntryFilterSpecification(organizationId)).ConfigureAwait(false);
+            var otherLaboratoryNumbers = entriesForOrganization.Select(e => e.LaboratoryNumber).Distinct().ToList();
+            otherLaboratoryNumbers.Sort();
+            return Ok(otherLaboratoryNumbers);
+        }
+    }
+}

--- a/NRZMyk.Server/Controllers/SentinelEntries/OtherLaboratoryNumbers.cs
+++ b/NRZMyk.Server/Controllers/SentinelEntries/OtherLaboratoryNumbers.cs
@@ -22,7 +22,7 @@ namespace NRZMyk.Server.Controllers.SentinelEntries
     {
         private readonly ISentinelEntryRepository _sentinelEntryRepository;
 
-        public OtherLaboratoryNumbers(ISentinelEntryRepository sentinelEntryRepository, IOptions<ApplicationSettings> config)
+        public OtherLaboratoryNumbers(ISentinelEntryRepository sentinelEntryRepository)
         {
             _sentinelEntryRepository = sentinelEntryRepository;
         }
@@ -35,14 +35,11 @@ namespace NRZMyk.Server.Controllers.SentinelEntries
         ]
         public override async Task<ActionResult<List<string>>> HandleAsync()
         {
-
             var organizationId = User.Claims.OrganizationId();
             if (string.IsNullOrEmpty(organizationId))
             {
                 return Forbid();
             }
-
-            var response = new ListPagedSentinelEntryResponse();
 
             var entriesForOrganization = await _sentinelEntryRepository.ListAsync(new SentinelEntryFilterSpecification(organizationId)).ConfigureAwait(false);
             var otherLaboratoryNumbers = entriesForOrganization.Select(e => e.LaboratoryNumber).Distinct().ToList();

--- a/NRZMyk.Server/Controllers/SentinelEntries/Update.cs
+++ b/NRZMyk.Server/Controllers/SentinelEntries/Update.cs
@@ -63,6 +63,15 @@ namespace NRZMyk.Server.Controllers.SentinelEntries
             {
                 await _sensitivityTestRepository.DeleteAsync(sensitivityTest).ConfigureAwait(false);
             }
+
+            existingItem.PredecessorEntryId = null;
+            existingItem.PredecessorEntry = null;
+
+            var error = await Utils.ResolvePredecessor(request, existingItem, _sentinelEntryRepository, organizationId, ModelState).ConfigureAwait(false);
+            if (error)
+            {
+                return new BadRequestObjectResult(ModelState);
+            }
             
             _mapper.Map(request, existingItem);
             await _sentinelEntryRepository.UpdateAsync(existingItem).ConfigureAwait(false);

--- a/NRZMyk.Server/Controllers/SentinelEntries/Utils.cs
+++ b/NRZMyk.Server/Controllers/SentinelEntries/Utils.cs
@@ -1,0 +1,30 @@
+﻿using NRZMyk.Services.Data;
+using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Services;
+using NRZMyk.Services.Specifications;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using NRZMyk.Services.Interfaces;
+
+namespace NRZMyk.Server.Controllers.SentinelEntries;
+
+public static class Utils
+{
+    public static async Task<bool> ResolvePredecessor(SentinelEntryRequest request, SentinelEntry newEntry,
+        IAsyncRepository<SentinelEntry>  repository, string organizationId, ModelStateDictionary modelState)
+    {
+        if (string.IsNullOrEmpty(request.PredecessorLaboratoryNumber)) return false;
+        
+        var predecessor = await repository.FirstOrDefaultAsync(
+            new SentinelEntryByLaboratoryNumberSpecification(request.PredecessorLaboratoryNumber, organizationId)).ConfigureAwait(false);
+
+        if (predecessor == null)
+        {
+            modelState.AddModelError($"{nameof(SentinelEntryRequest.PredecessorLaboratoryNumber)}", "Laboratory number can not be found");
+            return true;
+        }
+
+        newEntry.PredecessorEntryId = predecessor.Id;
+        return false;
+    }
+}

--- a/NRZMyk.Server/NRZMyk.Server.csproj
+++ b/NRZMyk.Server/NRZMyk.Server.csproj
@@ -12,11 +12,11 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -27,7 +27,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.6.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.39.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="6.0.3" />
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
   </ItemGroup>
 

--- a/NRZMyk.Services.Tests/Data/SentinelEntryRepositoryTests.cs
+++ b/NRZMyk.Services.Tests/Data/SentinelEntryRepositoryTests.cs
@@ -16,7 +16,7 @@ namespace NRZMyk.Services.Tests.Data
     {
         private ApplicationDbContext _dbContext;
 
-        private Filler<SentinelEntry> _filler = new Filler<SentinelEntry>();
+        private readonly Filler<SentinelEntry> _filler = new();
         
         [SetUp]
         public void Setup()
@@ -25,6 +25,9 @@ namespace NRZMyk.Services.Tests.Data
                 .UseInMemoryDatabase("TestCatalog")
                 .Options;
             _dbContext = new ApplicationDbContext(dbOptions);
+
+            _filler.Setup().OnProperty(e => e.PredecessorEntry).Use((SentinelEntry)null);
+            _filler.Setup().OnProperty(e => e.PredecessorEntryId).Use((int?)null);
         }
 
         [TearDown]

--- a/NRZMyk.Services.Tests/Export/SentinelEntryExportDefinitionTests.cs
+++ b/NRZMyk.Services.Tests/Export/SentinelEntryExportDefinitionTests.cs
@@ -43,7 +43,7 @@ namespace NRZMyk.Services.Tests.Export
 
             var export = sut.ToDataTable(SentinelEntries);
 
-            export.Columns.Count.Should().Be(13);
+            export.Columns.Count.Should().Be(14);
         }
 
         [Test]
@@ -63,6 +63,8 @@ namespace NRZMyk.Services.Tests.Export
             SentinelEntry.YearlySequentialEntryNumber = 123;
             SentinelEntry.CryoBoxNumber = 5;
             SentinelEntry.CryoBoxSlot = 67;
+            SentinelEntry.PredecessorEntry.Year = 2006;
+            SentinelEntry.PredecessorEntry.YearlySequentialEntryNumber = 6;
 
             var export = sut.ToDataTable(SentinelEntries);
 
@@ -76,6 +78,7 @@ namespace NRZMyk.Services.Tests.Export
             export.Rows[0]["Material"].Should().Be("Blutkultur zentral - ZVK");
             export.Rows[0]["Labnr. Einsender"].Should().Be("LabNr. 123");
             export.Rows[0]["Methode Speziesidentifikation"].Should().Be("BBL Crystal (Becton-Dickinson)");
+            export.Rows[0]["Labornummer Vorgänger"].Should().Be("SN-2006-0006");
         }
 
         [Test]
@@ -128,6 +131,19 @@ namespace NRZMyk.Services.Tests.Export
             export.Rows[0]["Methode Speziesidentifikation"].Should().Be("PCR: Details");
             export.Rows[0]["Station"].Should().Be("urologic");
             export.Rows[0]["Geschlecht"].Should().Be("weiblich");
+        }
+
+        
+        [Test]
+        public void DataTable_DoesNotContainEmptyPredecessor()
+        {
+            var sut = CreateExportDefinition(out _);
+
+            SentinelEntry.PredecessorEntry = null;
+            
+            var export = sut.ToDataTable(SentinelEntries);
+
+            export.Rows[0]["Labornummer Vorgänger"].Should().Be(DBNull.Value);
         }
 
         private SentinelEntryExportDefinition CreateExportDefinition(out IProtectKeyToOrganizationResolver organizationResolver)

--- a/NRZMyk.Services.Tests/NRZMyk.Services.Tests.csproj
+++ b/NRZMyk.Services.Tests/NRZMyk.Services.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
@@ -29,5 +29,9 @@
   <ItemGroup>
     <ProjectReference Include="..\NRZMyk.Mocks\NRZMyk.Mocks.csproj" />
     <ProjectReference Include="..\NRZMyk.Services\NRZMyk.Services.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Specifications\" />
   </ItemGroup>
 </Project>

--- a/NRZMyk.Services.Tests/Services/SentinelEntryServiceTests.cs
+++ b/NRZMyk.Services.Tests/Services/SentinelEntryServiceTests.cs
@@ -124,7 +124,7 @@ public class SentinelEntryServiceTests
         
         await sut.GetById(833).ConfigureAwait(true);
 
-        await httpClient.Received(1).Get<SentinelEntry>(
+        await httpClient.Received(1).Get<SentinelEntryResponse>(
             "api/sentinel-entries/833", default, Arg.Is<string>(s => !string.IsNullOrEmpty(s)));
     }
 

--- a/NRZMyk.Services.Tests/Specifications/SentinelEntryByLaboratoryNumberSpecificationTests.cs
+++ b/NRZMyk.Services.Tests/Specifications/SentinelEntryByLaboratoryNumberSpecificationTests.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+using NRZMyk.Services.Specifications;
+using NUnit.Framework;
+
+namespace NRZMyk.Services.Tests.Specifications;
+
+public class SentinelEntryByLaboratoryNumberSpecificationTests
+{
+    [Test]
+    public void Ctor_ParsesLaboratoryNumber()
+    {
+        var sut = new SentinelEntryByLaboratoryNumberSpecification("SN-2011-0233", "");
+
+        sut.Year.Should().Be(2011);
+        sut.SequentialNumber.Should().Be(233);
+    }
+
+    [TestCase("")]
+    [TestCase("SN-abc-0233")]
+    [TestCase("SN-2010-233")]
+    public void CtorInvalidNumber_UsesDefault(string laboratoryNumber)
+    {
+        var sut = new SentinelEntryByLaboratoryNumberSpecification(laboratoryNumber, "");
+
+        sut.Year.Should().Be(0);
+        sut.SequentialNumber.Should().Be(0);
+    }
+}

--- a/NRZMyk.Services/Data/ApplicationDbContext.cs
+++ b/NRZMyk.Services/Data/ApplicationDbContext.cs
@@ -30,13 +30,14 @@ namespace NRZMyk.Services.Data
                 .HasIndex(p => new {p.CryoBoxNumber , p.CryoBoxSlot}).IsUnique();
             builder.Entity<SentinelEntry>()
                 .HasIndex(p => new {p.Year , p.YearlySequentialEntryNumber}).IsUnique();
+            builder.Entity<SentinelEntry>()
+                .HasOne(b=>b.PredecessorEntry)
+                .WithMany()
+                .HasForeignKey(b=>b.PredecessorEntryId);
 
-            builder.Entity<RemoteAccount>().Property(
-                a => a.ObjectId).IsRequired();
-            builder.Entity<RemoteAccount>().Property(
-                a => a.Email).IsRequired();
-            builder.Entity<RemoteAccount>()
-                .HasIndex(a => a.ObjectId).IsUnique();
+            builder.Entity<RemoteAccount>().Property(a => a.ObjectId).IsRequired();
+            builder.Entity<RemoteAccount>().Property(a => a.Email).IsRequired();
+            builder.Entity<RemoteAccount>().HasIndex(a => a.ObjectId).IsUnique();
         }
     }
 }

--- a/NRZMyk.Services/Data/Entities/SentinelEntry.cs
+++ b/NRZMyk.Services/Data/Entities/SentinelEntry.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using NRZMyk.Services.Interfaces;
 
 namespace NRZMyk.Services.Data.Entities
 {
-    public class SentinelEntry : BaseEntity, IAggregateRoot
+    public class SentinelEntry : BaseEntity, IAggregateRoot, ISentinelEntry
     {
         [Display(Name = "Entnahmedatum")]
         public DateTime? SamplingDate { get; set; }
@@ -65,5 +66,14 @@ namespace NRZMyk.Services.Data.Entities
 
         [Display(Name = "Kryo-Kommentar")]
         public string CryoRemark { get; set; }
+
+        public YesNo HasPredecessor => PredecessorEntryId.HasValue ? YesNo.Yes : YesNo.No;
+
+        public string PredecessorLaboratoryNumber => PredecessorEntry?.LaboratoryNumber;
+        
+        public int? PredecessorEntryId {get;set;}
+
+        [JsonIgnore]
+        public virtual SentinelEntry PredecessorEntry {get;set;}
     }
 }

--- a/NRZMyk.Services/Data/Entities/YesNo.cs
+++ b/NRZMyk.Services/Data/Entities/YesNo.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel;
+
+namespace NRZMyk.Services.Data.Entities
+{
+    public enum YesNo
+    {
+        [Description("Nein")]
+        No = 0,
+        [Description("Ja")]
+        Yes = 1,
+    }
+}

--- a/NRZMyk.Services/Data/Migrations/20220328120500_SentinelEntry_Predecessor.Designer.cs
+++ b/NRZMyk.Services/Data/Migrations/20220328120500_SentinelEntry_Predecessor.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NRZMyk.Services.Data;
 
@@ -11,9 +12,10 @@ using NRZMyk.Services.Data;
 namespace NRZMyk.Services.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220328120500_SentinelEntry_Predecessor")]
+    partial class SentinelEntry_Predecessor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/NRZMyk.Services/Data/Migrations/20220328120500_SentinelEntry_Predecessor.cs
+++ b/NRZMyk.Services/Data/Migrations/20220328120500_SentinelEntry_Predecessor.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NRZMyk.Services.Data.Migrations
+{
+    public partial class SentinelEntry_Predecessor : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PredecessorEntryId",
+                table: "SentinelEntries",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SentinelEntries_PredecessorEntryId",
+                table: "SentinelEntries",
+                column: "PredecessorEntryId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SentinelEntries_SentinelEntries_PredecessorEntryId",
+                table: "SentinelEntries",
+                column: "PredecessorEntryId",
+                principalTable: "SentinelEntries",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SentinelEntries_SentinelEntries_PredecessorEntryId",
+                table: "SentinelEntries");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SentinelEntries_PredecessorEntryId",
+                table: "SentinelEntries");
+
+            migrationBuilder.DropColumn(
+                name: "PredecessorEntryId",
+                table: "SentinelEntries");
+        }
+    }
+}

--- a/NRZMyk.Services/Export/SentinelEntryExportDefinition.cs
+++ b/NRZMyk.Services/Export/SentinelEntryExportDefinition.cs
@@ -26,6 +26,7 @@ namespace HaemophilusWeb.Tools
             AddField(s => s.SpeciesIdentificationMethodWithPcrDetails(), "Methode Speziesidentifikation");
             AddField(s => s.SpeciesOrOther(), "Spezies");
             AddField(s => ResolveSender(s), "Einsender");
+            AddField(s => s.PredecessorLaboratoryNumber, "Labornummer Vorgänger");
         }
 
         private static string ToReportFormat(DateTime? dateTime)

--- a/NRZMyk.Services/Interfaces/ISentinelEntry.cs
+++ b/NRZMyk.Services/Interfaces/ISentinelEntry.cs
@@ -1,0 +1,15 @@
+﻿using NRZMyk.Services.Data.Entities;
+
+namespace NRZMyk.Services.Interfaces;
+
+public interface ISentinelEntry
+{
+    public Material Material { get; set; }
+    public string OtherMaterial { get; set; }
+    public Species IdentifiedSpecies { get; set; }
+    public string OtherIdentifiedSpecies { get; set; }
+    public HospitalDepartment HospitalDepartment { get; set; }
+    public string OtherHospitalDepartment { get; set; }
+    public SpeciesIdentificationMethod SpeciesIdentificationMethod { get; set; }
+    public string PcrDetails { get; set; }
+}

--- a/NRZMyk.Services/MappingProfile.cs
+++ b/NRZMyk.Services/MappingProfile.cs
@@ -9,7 +9,9 @@ namespace NRZMyk.Services
         public MappingProfile()
         {
             CreateMap<SentinelEntryRequest, SentinelEntry>();
-            CreateMap<SentinelEntry, SentinelEntryRequest>();
+            CreateMap<SentinelEntry, SentinelEntryResponse>();
+            //CreateMap <SentinelEntryRequest, SentinelEntryResponse>();
+            CreateMap<SentinelEntryResponse, SentinelEntryRequest>();
             CreateMap<AntimicrobialSensitivityTestRequest, AntimicrobialSensitivityTest>();
             CreateMap<AntimicrobialSensitivityTest, AntimicrobialSensitivityTestRequest>().ForMember(
                 dest => dest.Standard,

--- a/NRZMyk.Services/ModelExtensions/SentinelEntryExtensions.cs
+++ b/NRZMyk.Services/ModelExtensions/SentinelEntryExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Interfaces;
 using NRZMyk.Services.Services;
 using NRZMyk.Services.Utils;
 
@@ -6,35 +7,28 @@ namespace NRZMyk.Services.ModelExtensions
 {
     public static class SentinelEntryExtensions
     {
-        public static string MaterialOrOther(this SentinelEntryRequest sentinelEntry)
+        public static string MaterialOrOther(this ISentinelEntry sentinelEntry)
         {
             return sentinelEntry.Material == Material.Other
                 ? sentinelEntry.OtherMaterial
                 : EnumUtils.GetEnumDescription(sentinelEntry.Material);
         }
 
-        public static string MaterialOrOther(this SentinelEntry sentinelEntry)
-        {
-            return sentinelEntry.Material == Material.Other
-                ? sentinelEntry.OtherMaterial
-                : EnumUtils.GetEnumDescription(sentinelEntry.Material);
-        }
-
-        public static string SpeciesOrOther(this SentinelEntry sentinelEntry)
+        public static string SpeciesOrOther(this ISentinelEntry sentinelEntry)
         {
             return sentinelEntry.IdentifiedSpecies == Species.Other
                 ? sentinelEntry.OtherIdentifiedSpecies
                 : EnumUtils.GetEnumDescription(sentinelEntry.IdentifiedSpecies);
         }
 
-        public static string HospitalDepartementOrOther(this SentinelEntry sentinelEntry)
+        public static string HospitalDepartementOrOther(this ISentinelEntry sentinelEntry)
         {
             return sentinelEntry.HospitalDepartment == HospitalDepartment.Other
                 ? sentinelEntry.OtherHospitalDepartment
                 : EnumUtils.GetEnumDescription(sentinelEntry.HospitalDepartment);
         }
 
-        public static string SpeciesIdentificationMethodWithPcrDetails(this SentinelEntry sentinelEntry)
+        public static string SpeciesIdentificationMethodWithPcrDetails(this ISentinelEntry sentinelEntry)
         {
             return sentinelEntry.SpeciesIdentificationMethod == SpeciesIdentificationMethod.Pcr
                 ? $"{EnumUtils.GetEnumDescription(SpeciesIdentificationMethod.Pcr)}: {sentinelEntry.PcrDetails}"

--- a/NRZMyk.Services/NRZMyk.Services.csproj
+++ b/NRZMyk.Services/NRZMyk.Services.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.0.0" />
     <PackageReference Include="EPPlus" Version="5.3.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
     <PackageReference Include="Ardalis.Specification" Version="3.0.0" />
     <PackageReference Include="SendGrid" Version="9.22.0" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />

--- a/NRZMyk.Services/Services/ISentinelEntryService.cs
+++ b/NRZMyk.Services/Services/ISentinelEntryService.cs
@@ -9,7 +9,7 @@ public interface ISentinelEntryService
     Task<SentinelEntry> Create(SentinelEntryRequest createRequest);
     Task<List<SentinelEntry>> ListPaged(int pageSize);
     Task<List<SentinelEntry>> ListByOrganization(int organizationId);
-    Task<SentinelEntry> GetById(int id);
+    Task<SentinelEntryResponse> GetById(int id);
     Task<SentinelEntry> Update(SentinelEntryRequest updateRequest);
     Task<SentinelEntry> CryoArchive(CryoArchiveRequest archiveRequest);
     Task<string> Export();

--- a/NRZMyk.Services/Services/SentinelEntryRequest.cs
+++ b/NRZMyk.Services/Services/SentinelEntryRequest.cs
@@ -2,12 +2,13 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Interfaces;
 using NRZMyk.Services.Models;
 using NRZMyk.Services.Validation;
 
 namespace NRZMyk.Services.Services
 {
-    public class SentinelEntryRequest
+    public class SentinelEntryRequest : ISentinelEntry
     {
         public int Id { get; set; }
 
@@ -48,7 +49,11 @@ namespace NRZMyk.Services.Services
         public string Remark { get; set; }
 
         public Gender Gender { get; set; }
-        
+
+        public YesNo HasPredecessor { get; set; }
+
+        [OtherValue((int) YesNo.Yes, nameof(HasPredecessor), ErrorMessage = "Das Feld Labornummer Vorgänger ist erforderlich")]
+        public string PredecessorLaboratoryNumber { get; set; }
         
         [SensitivityTestNotEmptyWithoutComment(
             ErrorMessage = "Mindestens ein MHK Eintrag ist erforderlich. Schreiben sie bitte einen Erklärung in die Anmerkungen, falls es keine MHKs ermitteln konnten." )]

--- a/NRZMyk.Services/Services/SentinelEntryResponse.cs
+++ b/NRZMyk.Services/Services/SentinelEntryResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace NRZMyk.Services.Services;
+
+public class SentinelEntryResponse : SentinelEntryRequest
+{
+    public string LaboratoryNumber { get; set; }
+
+    public string CryoBox { get; set; }
+
+    public DateTime? CryoDate { get; set; }
+}

--- a/NRZMyk.Services/Services/SentinelEntryService.cs
+++ b/NRZMyk.Services/Services/SentinelEntryService.cs
@@ -35,8 +35,8 @@ namespace NRZMyk.Services.Services
         public Task<List<SentinelEntry>> ListByOrganization(int organizationId)
             => _httpClient.Get<List<SentinelEntry>>($"{BaseApi}/organization/{organizationId}");
 
-        public Task<SentinelEntry> GetById(int id)
-            => _httpClient.Get<SentinelEntry>($"{BaseApi}/{id}");
+        public Task<SentinelEntryResponse> GetById(int id)
+            => _httpClient.Get<SentinelEntryResponse>($"{BaseApi}/{id}");
 
         public async Task<List<SentinelEntry>> ListPaged(int pageSize)
         {

--- a/NRZMyk.Services/Specifications/SentinelEntryByLaboratoryNumberSpecification.cs
+++ b/NRZMyk.Services/Specifications/SentinelEntryByLaboratoryNumberSpecification.cs
@@ -1,0 +1,35 @@
+﻿using System.Text.RegularExpressions;
+using Ardalis.Specification;
+using NRZMyk.Services.Data.Entities;
+
+namespace NRZMyk.Services.Specifications
+{
+    public sealed class SentinelEntryByLaboratoryNumberSpecification : SentinelEntryFilterSpecification
+    {
+        private static readonly Regex LaboratoryNumberFormat = new Regex("SN-(\\d\\d\\d\\d)-(\\d\\d\\d\\d)", RegexOptions.Compiled);
+
+        public int Year { get; }
+
+        public int SequentialNumber { get; }
+
+        public SentinelEntryByLaboratoryNumberSpecification(string laboratoryNumber, string protectKey) : base(protectKey)
+        {
+            Year = ParseYear(laboratoryNumber);
+            SequentialNumber = ParseSequentialNumber(laboratoryNumber);
+
+            AddCriteria(s => s.Year == Year && s.YearlySequentialEntryNumber == SequentialNumber);
+        }
+
+        private static int ParseYear(string laboratoryNumber)
+        {
+            int.TryParse(LaboratoryNumberFormat.Match(laboratoryNumber).Groups[1].Value, out var year);
+            return year;
+        }
+
+        private static int ParseSequentialNumber(string laboratoryNumber)
+        {
+            int.TryParse(LaboratoryNumberFormat.Match(laboratoryNumber).Groups[2].Value, out var sequentialNumber);
+            return sequentialNumber;
+        }
+    }
+}

--- a/NRZMyk.Services/Specifications/SentinelEntryIncludingTestsSpecification.cs
+++ b/NRZMyk.Services/Specifications/SentinelEntryIncludingTestsSpecification.cs
@@ -11,6 +11,7 @@ namespace NRZMyk.Services.Specifications
         {
             Id = id;
             AddInclude(b => b.AntimicrobialSensitivityTests);
+            AddInclude(b => b.PredecessorEntry);
             AddInclude($"{nameof(SentinelEntry.AntimicrobialSensitivityTests)}.{nameof(AntimicrobialSensitivityTest.ClinicalBreakpoint)}");
         }
     }


### PR DESCRIPTION
Adds field to mark an entry as follow-up. This requires some more rework
on data structure level. Especially the "handy" leakage of entites to
API view models from the early days fell flat on it's feet.

This marks one step towards a clean response model.
