### PR TITLE
Improve UX for cryo view (#108)

### DIFF
--- a/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CryoViewTests.cs
+++ b/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CryoViewTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using Bunit;
@@ -47,7 +48,7 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
         {
             var sut = _renderedComponent.Instance;
 
-             sut.SelectedOrganization = 10;
+            sut.SelectedOrganization = 10;
             await sut.LoadData().ConfigureAwait(true);
 
             _renderedComponent.Markup.Should().Contain(
@@ -69,10 +70,12 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
         public async Task WhenPutToCryo_ShowsRemark()
         {
             var sut = _renderedComponent.Instance;
-
             sut.SelectedOrganization = 1;
-            await sut.PutToCryoStorage(
-                new SentinelEntry{Id=1, CryoRemark = "Duplicate to SN-133422"}).ConfigureAwait(true);
+            await sut.LoadData().ConfigureAwait(true);
+
+            var cryoEntry = sut.SentinelEntries.First();
+            cryoEntry.CryoRemark = "Duplicate to SN-133422";
+            await sut.PutToCryoStorage(cryoEntry).ConfigureAwait(true);
 
             _renderedComponent.Markup.Should().Contain("Duplicate to SN-133422");
             var entry = await _sentinelEntryService.GetById(1).ConfigureAwait(true);
@@ -83,12 +86,12 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
         public async Task WhenReleaseFromCryoStorage_ShowsRemarkAndClearsDate()
         {
             var sut = _renderedComponent.Instance;
-
             sut.SelectedOrganization = 1;
-            await sut.ReleaseFromCryoStorage(
-                new SentinelEntry{Id=1, CryoRemark = "Wrongly sent specimen"}).ConfigureAwait(true);
+            await sut.LoadData().ConfigureAwait(true);
 
-            _renderedComponent.Markup.Should().Contain("Wrongly sent specimen");
+            var cryoEntry = sut.SentinelEntries.First();
+            await sut.ReleaseFromCryoStorage(cryoEntry).ConfigureAwait(true);
+
             var entry = await _sentinelEntryService.GetById(1).ConfigureAwait(true);
             entry.CryoDate.Should().BeNull();
         }

--- a/NRZMyk.Components/Pages/SentinelEntryPage/CryoView.razor
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/CryoView.razor
@@ -6,6 +6,7 @@
 @using NRZMyk.Services.Models
 @using NRZMyk.Services.Services
 @using NRZMyk.Components.Helpers
+@using Microsoft.Graph
 
 @inherits CryoViewBase
 
@@ -71,25 +72,42 @@ else
                             <td>@item.SenderLaboratoryNumber</td>
                             <td>@item.MaterialOrOther()</td>
                             <td>
-                                @if (item.SamplingDate.HasValue)
+                                @if(IsUpdating(item))
                                 {
-                                    @item.SamplingDate.Value.ToShortDateString();
+                                    <div class="spinner-border spinner-border-sm text-secondary" role="status">
+                                    </div>
+                                }
+                                else if (item.SamplingDate.HasValue)
+                                {
+                                    @item.SamplingDate.Value.ToShortDateString()
+                                    ;
                                 }
                             </td>
                             <td>@item.SpeciesOrOther()</td>
                             <td>@item.CryoDate?.ToShortDateString()</td>
                             <td>
-                                @if (item.CryoDate.HasValue)
+                                @if(IsUpdating(item))
+                                {
+                                    <div class="spinner-border spinner-border-sm text-secondary" role="status">
+                                    </div>
+                                }
+                                else if (item.CryoDate.HasValue)
                                 {
                                     @item.CryoRemark
                                 }
                                 else
                                 {
-                                    <InputText class="form-control form-control-sm" @bind-Value="item.CryoRemark" />
+                                    <InputText class="form-control form-control-sm" @bind-Value="item.CryoRemark"/>
                                 }
                             </td>
                             <td>
-                                @if (item.CryoDate.HasValue)
+                                @if(IsUpdating(item))
+                                {
+                                    <a title="Lädt" href="#" @onclick="() => { }" @onclick:preventDefault class="disabled btn btn-sm btn-secondary">
+                                        <i class="oi oi-clock" ></i>
+                                    </a>
+                                }
+                                else if(item.CryoDate.HasValue)
                                 {
                                     <a title="Aus Cryobox entfernen" href="" @onclick="() => ReleaseFromCryoStorage(item)" @onclick:preventDefault class="btn btn-sm btn-danger">
                                         <i class="oi oi-data-transfer-upload"></i>

--- a/NRZMyk.Components/Pages/SentinelEntryPage/CryoViewBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/CryoViewBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using AutoMapper;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using NRZMyk.Components.Helpers;
 using NRZMyk.Services.Data.Entities;
@@ -10,6 +11,9 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
     {
         [Inject]
         private IAccountService AccountService { get; set; } = default!;
+        
+        [Inject]
+        private IMapper Mapper { get; set; } = default!;
 
         [Inject]
         private ISentinelEntryService SentinelEntryService { get; set; } = default!;
@@ -19,12 +23,14 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
 
         internal ICollection<Organization> Organizations { get; set; } = default!;
 
-        protected List<SentinelEntry> SentinelEntries { get; set; } = default!;
+        internal List<SentinelEntryResponse> SentinelEntries { get; set; } = default!;
 
         internal int SelectedOrganization { get; set; }
         
         protected LoadState LoadState { get; set; }
-        
+
+        private readonly List<int> _updatingItems = new();
+
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
@@ -33,7 +39,7 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
 
                 Organizations = await AccountService.ListOrganizations().ConfigureAwait(true);
                 SelectedOrganization = Organizations.First().Id;
-                SentinelEntries = new List<SentinelEntry>();
+                SentinelEntries = new List<SentinelEntryResponse>();
 
                 await InvokeAsync(CallRequestRefresh).ConfigureAwait(true);
             }
@@ -41,41 +47,48 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
             await base.OnAfterRenderAsync(firstRender).ConfigureAwait(true);
         }
 
-        internal async Task PutToCryoStorage(SentinelEntry entry)
+        internal Task PutToCryoStorage(SentinelEntryResponse entry)
         {
-            LoadState = LoadState.Loading;
+            return CryoStore(entry, true);
+        }
+
+        internal Task ReleaseFromCryoStorage(SentinelEntryResponse entry)
+        {
+            return CryoStore(entry, false);
+        }
+
+        private async Task CryoStore(SentinelEntryResponse entry, bool store)
+        {
+            _updatingItems.Add(entry.Id);
             await SentinelEntryService.CryoArchive(new CryoArchiveRequest
             {
                 Id = entry.Id,
-                CryoDate = DateTime.Now,
+                CryoDate = store ? DateTime.Now : null,
                 CryoRemark = entry.CryoRemark
             }).ConfigureAwait(true);
-            await LoadData().ConfigureAwait(true);
+
+            var index = SentinelEntries.IndexOf(entry);
+            var updatedEntry = await SentinelEntryService.GetById(entry.Id);
+            SentinelEntries[index] =  updatedEntry;
+            _updatingItems.Remove(entry.Id);
+            await InvokeAsync(StateHasChanged).ConfigureAwait(true);
         }
-
-
-        internal async Task ReleaseFromCryoStorage(SentinelEntry entry)
-        {
-            LoadState = LoadState.Loading;
-            await SentinelEntryService.CryoArchive(new CryoArchiveRequest
-            {
-                Id = entry.Id,
-                CryoDate = null,
-                CryoRemark = entry.CryoRemark
-            }).ConfigureAwait(true);
-            await LoadData().ConfigureAwait(true);
-        }
-
 
         internal async Task LoadData()
         {
             LoadState = LoadState.Loading;
 
-            SentinelEntries = await SentinelEntryService.ListByOrganization(SelectedOrganization).ConfigureAwait(true);
+            SentinelEntries = Mapper.Map<List<SentinelEntryResponse>>(
+                await SentinelEntryService.ListByOrganization(SelectedOrganization).ConfigureAwait(true));
 
             LoadState = LoadState.Loaded;
 
             await InvokeAsync(StateHasChanged).ConfigureAwait(true);
+        }
+
+        internal bool IsUpdating(SentinelEntryResponse entry)
+        {
+            return _updatingItems.Contains(entry.Id);
         }
     }
 }

--- a/NRZMyk.Components/Pages/SentinelEntryPage/CryoViewBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/CryoViewBase.cs
@@ -68,7 +68,7 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
             }).ConfigureAwait(true);
 
             var index = SentinelEntries.IndexOf(entry);
-            var updatedEntry = await SentinelEntryService.GetById(entry.Id);
+            var updatedEntry = await SentinelEntryService.GetById(entry.Id).ConfigureAwait(true);
             SentinelEntries[index] =  updatedEntry;
             _updatingItems.Remove(entry.Id);
             await InvokeAsync(StateHasChanged).ConfigureAwait(true);

--- a/NRZMyk.Services/Services/SentinelEntryResponse.cs
+++ b/NRZMyk.Services/Services/SentinelEntryResponse.cs
@@ -9,4 +9,6 @@ public class SentinelEntryResponse : SentinelEntryRequest
     public string CryoBox { get; set; }
 
     public DateTime? CryoDate { get; set; }
+
+    public string CryoRemark { get; set; }
 }


### PR DESCRIPTION
Hiding the table triggered a scroll reset on cryo view. Additionally
the full reload queried too much data from backend.

Change behavior to only reload the updated entry and show loading
activity only inline.
