### PR TITLE
feat: Floor mic values to closest reference step

### DIFF
--- a/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CreateTests.cs
+++ b/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CreateTests.cs
@@ -264,6 +264,30 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
             sensitivityTest.Resistance.Should().Be(expectedResistance);
         }
 
+        [Test]
+        public void WhenCalculateResistanceBadge_FloorsMicToClosestReferenceValue()
+        {
+            var component = CreateSut();
+            var sut = component.Instance;
+            sut.SentinelEntry.IdentifiedSpecies = Species.CandidaKrusei;
+            var breakpoint = sut.AllBreakpoints.Single(b => 
+                b.AntifungalAgent == AntifungalAgent.Anidulafungin
+                && b.Species == Species.CandidaKrusei
+                && b.Standard == BrothMicrodilutionStandard.Eucast
+                && b.Version == "10.0");
+            var sensitivityTest = new AntimicrobialSensitivityTestRequest
+            {
+                ClinicalBreakpointId = breakpoint.Id,
+                MinimumInhibitoryConcentration = 0.064f
+            };
+            sut.SentinelEntry.AntimicrobialSensitivityTests.Add(sensitivityTest);
+
+            var badge = sut.ResistanceBadge(sensitivityTest);
+
+            badge.Should().Be("bg-success");
+            sensitivityTest.Resistance.Should().Be(Resistance.Susceptible);
+        }
+
         [TestCase(0.01f, "bg-danger", Resistance.Resistant)]
         [TestCase(0f, "bg-danger", Resistance.Resistant)]
         [TestCase(-0.01f, "bg-warning", Resistance.Intermediate)]

--- a/NRZMyk.Components/Pages/SentinelEntryPage/CreateBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/CreateBase.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using NRZMyk.Components.Helpers;
 using NRZMyk.Services.Data.Entities;
+using NRZMyk.Services.Extensions;
 using NRZMyk.Services.Interfaces;
 using NRZMyk.Services.Services;
 using NRZMyk.Services.Models;
@@ -184,22 +185,21 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
                 }
             }
 
-
             Logger.LogInformation($"Found breakpoint for {sensitivityTest.TestingMethod}/{sensitivityTest.AntifungalAgent} where id is {sensitivityTest.ClinicalBreakpointId}: {breakpoint.Title}");
 
             var mic = MicStepsService.FloorToClosestReferenceValue(sensitivityTest.MinimumInhibitoryConcentration);
             
-            if (IsResistantAccordingToEucastDefinition(mic, breakpoint))
+            if (mic.IsResistantAccordingToEucastDefinition(breakpoint))
             {
                 sensitivityTest.Resistance = Resistance.Resistant;
                 return "bg-danger";
             }
-            if (IsResistantAccordingToClsiDefinition(mic, breakpoint))
+            if (mic.IsResistantAccordingToClsiDefinition(breakpoint))
             {
                 sensitivityTest.Resistance = Resistance.Resistant;
                 return "bg-danger";
             }
-            if (IsSusceptibleAccordingToBothDefinitions(mic, breakpoint))
+            if (mic.IsSusceptibleAccordingToBothDefinitions(breakpoint))
             {
                 sensitivityTest.Resistance = Resistance.Susceptible;
                 return "bg-success";
@@ -219,20 +219,7 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
             return isInternalNormalUnit;
         }
 
-        private static bool IsResistantAccordingToEucastDefinition(float? mic, ClinicalBreakpoint breakpoint)
-        {
-            return mic > breakpoint.MicBreakpointResistent && breakpoint.Standard == BrothMicrodilutionStandard.Eucast;
-        }
-
-        private static bool IsResistantAccordingToClsiDefinition(float? mic, ClinicalBreakpoint breakpoint)
-        {
-            return mic >= breakpoint.MicBreakpointResistent && breakpoint.Standard == BrothMicrodilutionStandard.Clsi;
-        }
-
-        private static bool IsSusceptibleAccordingToBothDefinitions(float? mic, ClinicalBreakpoint breakpoint)
-        {
-            return mic <= breakpoint.MicBreakpointSusceptible;
-        }
+       
 
         internal async Task SubmitClick()
         {

--- a/NRZMyk.Components/Pages/SentinelEntryPage/CreateBase.cs
+++ b/NRZMyk.Components/Pages/SentinelEntryPage/CreateBase.cs
@@ -187,7 +187,8 @@ namespace NRZMyk.Components.Pages.SentinelEntryPage
 
             Logger.LogInformation($"Found breakpoint for {sensitivityTest.TestingMethod}/{sensitivityTest.AntifungalAgent} where id is {sensitivityTest.ClinicalBreakpointId}: {breakpoint.Title}");
 
-            var mic = sensitivityTest.MinimumInhibitoryConcentration;
+            var mic = MicStepsService.FloorToClosestReferenceValue(sensitivityTest.MinimumInhibitoryConcentration);
+            
             if (IsResistantAccordingToEucastDefinition(mic, breakpoint))
             {
                 sensitivityTest.Resistance = Resistance.Resistant;

--- a/NRZMyk.Mocks/MockServices/MockMicStepsService.cs
+++ b/NRZMyk.Mocks/MockServices/MockMicStepsService.cs
@@ -40,6 +40,9 @@ namespace NRZMyk.Mocks.MockServices
             return true;
         }
 
-
+        public float? FloorToClosestReferenceValue(float? micValue)
+        {
+            return micValue.Equals(0.064f) ? 0.06f : micValue;
+        }
     }
 }

--- a/NRZMyk.Mocks/MockServices/MockSentinelEntryServiceImpl.cs
+++ b/NRZMyk.Mocks/MockServices/MockSentinelEntryServiceImpl.cs
@@ -114,7 +114,7 @@ namespace NRZMyk.Mocks.MockServices
         public async Task<SentinelEntry> CryoArchive(CryoArchiveRequest archiveRequest)
         {
             await Task.Delay(Delay);
-            var entry = _repository.FirstOrDefault(e => e.Id == archiveRequest.Id);
+            var entry = _repository.First(e => e.Id == archiveRequest.Id);
             entry.CryoRemark = archiveRequest.CryoRemark;
             entry.CryoDate = archiveRequest.CryoDate;
             return entry;

--- a/NRZMyk.Services.Tests/Services/MicStepServiceTests.cs
+++ b/NRZMyk.Services.Tests/Services/MicStepServiceTests.cs
@@ -26,6 +26,37 @@ namespace NRZMyk.Services.Tests.Services
         }
 
         [Test]
+        public void FloorToClosesReferenceValue_WhenNotConfigured_KeepsValueAsIs()
+        {
+            var sut = CreateSut(Options.Create(new BreakpointSettings()));
+
+            sut.FloorToClosestReferenceValue(0.64f).Should().Be(0.64f);
+        }
+
+        [TestCase(null, null)]
+        [TestCase(0.064f, 0.06f)]
+        [TestCase(0.004f, 0.004f)]
+        [TestCase(0.004f, 0.004f)]
+        [TestCase(0.001f, 0.001f)]
+        [TestCase(16f, 8.001f)]
+        public void FloorToClosesReferenceValue_WithRefValuesConfigured_FloorsCorrectly(float? micValue, float? expectedFlooredValue)
+        {
+            var sut = CreateSut(Options.Create(
+                new BreakpointSettings
+                {
+                    Breakpoint = new Breakpoint
+                    {
+                        ReferenceMethodMicValues = new List<float>
+                        {
+                            0.002f, 0.008f,  0.016f, 0.03f, 0.06f, 0.12f, 0.25f, 0.5f, 1f, 2f, 4f, 8f, 8.001f, 0.004f
+                        }
+                    }
+                }));
+
+            sut.FloorToClosestReferenceValue(micValue).Should().Be(expectedFlooredValue);
+        }
+
+        [Test]
         public void WhenStandardsNotConfigured_ReturnsAllValues()
         {
             var expectedStandards = EnumUtils.AllEnumValues<BrothMicrodilutionStandard>().ToList();

--- a/NRZMyk.Services/Configuration/Breakpoint.cs
+++ b/NRZMyk.Services/Configuration/Breakpoint.cs
@@ -7,6 +7,7 @@ namespace NRZMyk.Services.Configuration
     public class Breakpoint
     {
         public List<SpeciesTestingMethod> MultiAgentSystems { get; set; }
+        public List<float> ReferenceMethodMicValues { get; set; }
         public Dictionary<SpeciesTestingMethod, List<BrothMicrodilutionStandard>> Standards { get; set; }
         public Dictionary<SpeciesTestingMethod, Dictionary<AntifungalAgent, List<MicStep>>> MicSteps { get; set; }
     }

--- a/NRZMyk.Services/Configuration/BreakpointSettings.json
+++ b/NRZMyk.Services/Configuration/BreakpointSettings.json
@@ -2,12 +2,15 @@
   "Breakpoint": {
     "MultiAgentSystems": ["Vitek", "YeastOne", "Micronaut" ],
     "Standards": {
-      "Vitek": ["EUCAST", "CLSI"],
-      "YeastOne": ["CLSI"],
-      "Micronaut": ["EUCAST"],
-      "Microdilution": ["EUCAST", "CLSI"],
-      "ETest": ["EUCAST", "CLSI"]
+      "Vitek": [ "EUCAST", "CLSI" ],
+      "YeastOne": [ "CLSI" ],
+      "Micronaut": [ "EUCAST" ],
+      "Microdilution": [ "EUCAST", "CLSI" ],
+      "ETest": [ "EUCAST", "CLSI" ]
     },
+    "ReferenceMethodMicValues": [ 
+      0.002, 0.004, 0.008, 0.016, 0.03, 0.06, 0.12, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 256.001
+    ],
     "MicSteps": {
       "Vitek": {
         "Micafungin": [

--- a/NRZMyk.Services/Extensions/ClinicalBreakpointExtensions.cs
+++ b/NRZMyk.Services/Extensions/ClinicalBreakpointExtensions.cs
@@ -1,0 +1,21 @@
+﻿using NRZMyk.Services.Data.Entities;
+
+namespace NRZMyk.Services.Extensions;
+
+public static class ClinicalBreakpointExtensions
+{
+    public static bool IsResistantAccordingToEucastDefinition(this float? mic, ClinicalBreakpoint breakpoint)
+    {
+        return mic > breakpoint.MicBreakpointResistent && breakpoint.Standard == BrothMicrodilutionStandard.Eucast;
+    }
+
+    public static bool IsResistantAccordingToClsiDefinition(this float? mic, ClinicalBreakpoint breakpoint)
+    {
+        return mic >= breakpoint.MicBreakpointResistent && breakpoint.Standard == BrothMicrodilutionStandard.Clsi;
+    }
+
+    public static bool IsSusceptibleAccordingToBothDefinitions(this float? mic, ClinicalBreakpoint breakpoint)
+    {
+        return mic <= breakpoint.MicBreakpointSusceptible;
+    }
+}

--- a/NRZMyk.Services/Interfaces/IMicStepsService.cs
+++ b/NRZMyk.Services/Interfaces/IMicStepsService.cs
@@ -11,5 +11,6 @@ namespace NRZMyk.Services.Interfaces
         IEnumerable<AntifungalAgent> AntifungalAgents(SpeciesTestingMethod testingMethod);
         IEnumerable<BrothMicrodilutionStandard> Standards(SpeciesTestingMethod testingMethod);
         bool IsMultiAgentSystem(SpeciesTestingMethod testingMethod);
+        float? FloorToClosestReferenceValue(float? micValue);
     }
 }


### PR DESCRIPTION
E-Test has its own range of MIC-values but this technique is always
compared with and evaluated by the MIC ranges of the reference
methode broth microdilution. Therefore e.g. only 0.06 and 0.125 do
matter as endpoints of the readout and serve for a breakpoint
evaluation.

Everything in between these values do not exsist in the ref methode. that is why if these strains do not reach the next MIC of 0.125 they have to be evaluated as susceptible.

E.g. a value of 0.064 should be interpreted as 0.06. When a breakpoint
is set as >0.06, 0.06 and 0.064 should be reported as susceptible.

Refs: #131
