### PR TITLE
Require sending to only arrive on the correct year

### DIFF
--- a/.github/workflows/sonarbuild.yml
+++ b/.github/workflows/sonarbuild.yml
@@ -47,6 +47,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: bash
         run: |
-          ./.sonar/scanner/dotnet-sonarscanner begin -k:"markusrt_NRZMyk" -o:"markusrt" -d:sonar.login="${{ secrets.SONAR_TOKEN }}" -d:sonar.host.url="https://sonarcloud.io" -d:sonar.cs.vstest.reportsPaths="**/*.trx" -d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" -d:sonar.exclusions="**/Migrations/*"
+          ./.sonar/scanner/dotnet-sonarscanner begin -k:"markusrt_NRZMyk" -o:"markusrt" -d:sonar.token="${{ secrets.SONAR_TOKEN }}" -d:sonar.host.url="https://sonarcloud.io" -d:sonar.cs.vstest.reportsPaths="**/*.trx" -d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" -d:sonar.exclusions="**/Migrations/*,**/*.sql"
           dotnet test -c Release -p:CollectCoverage=true -p:CoverletOutputFormat=\"json,opencover\" -p:SkipAutoProps=true -p:MergeWith=./coverage.json -p:CoverletOutput=./coverage
-          ./.sonar/scanner/dotnet-sonarscanner end -d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          ./.sonar/scanner/dotnet-sonarscanner end -d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/NRZMyk.Client/Program.cs
+++ b/NRZMyk.Client/Program.cs
@@ -23,6 +23,7 @@ builder.Services.AddHttpClient("NRZMyk.ServerAPI",
 builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>()
     .CreateClient("NRZMyk.ServerAPI"));
 builder.Services.AddScoped<IHttpClient, LoggingJsonHttpClient>();
+builder.Services.AddSingleton(TimeProvider.System);
 
 // Custom services start
 

--- a/NRZMyk.Component.Playground/Program.cs
+++ b/NRZMyk.Component.Playground/Program.cs
@@ -26,7 +26,7 @@ builder.Services.AddSingleton<IEmailNotificationService, MockEmailNotificationSe
 builder.Services.AddSingleton<IReminderService, ReminderService>();
 
 builder.Services.AddScoped<AuthenticationStateProvider, MockAuthStateProvider>();
-builder.Services.AddScoped<SignOutSessionStateManager>();
+builder.Services.AddSingleton(TimeProvider.System);
 
 
 var app = builder.Build();

--- a/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CreateTests.cs
+++ b/NRZMyk.Components.Tests/Pages/SentinelEntryPage/CreateTests.cs
@@ -43,7 +43,6 @@ namespace NRZMyk.ComponentsTests.Pages.SentinelEntryPage
             _context.Services.AddSingleton<IClinicalBreakpointService>(_mockClinicalBreakpointService);
             _context.Services.AddSingleton<IMicStepsService>(_mockMicStepsService);
             _context.Services.AddScoped<AuthenticationStateProvider, MockAuthStateProvider>();
-            _context.Services.AddScoped<SignOutSessionStateManager>();
             _context.Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 
             _sentinelEntryService = _context.Services.GetService<ISentinelEntryService>();

--- a/NRZMyk.Server/Program.cs
+++ b/NRZMyk.Server/Program.cs
@@ -51,6 +51,8 @@ builder.Services.AddApplicationInsightsTelemetry();
 
 builder.Services.AddAutoMapper(typeof(Program).Assembly, typeof(ISentinelEntryService).Assembly);
 
+
+builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddScoped<IGraphServiceClient, GraphServiceClientWrapper>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped(typeof(IAsyncRepository<>), typeof(EfRepository<>));

--- a/NRZMyk.Services.Tests/NRZMyk.Services.Tests.csproj
+++ b/NRZMyk.Services.Tests/NRZMyk.Services.Tests.csproj
@@ -13,6 +13,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.12" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />


### PR DESCRIPTION
Independent of the scheduled month a sending is treated as correctly arrived
if it is received within the same year as the scheduled year.
